### PR TITLE
chore: update typos

### DIFF
--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -93,7 +93,7 @@ class PostgresVectorStore(VectorStore):
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
     ):
-        """Constructor for CloudSQLVectorStore.
+        """Constructor for PostgresVectorStore.
         Args:
             engine (PostgresEngine): AsyncEngine with pool connection to the postgres database. Required.
             embedding_service (Embeddings): Text embedding model to use.

--- a/tests/test_cloudsql_vectorstore.py
+++ b/tests/test_cloudsql_vectorstore.py
@@ -35,7 +35,7 @@ docs = [
     Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
 
-embeddings = [embeddings_service.embed_query("foo") for i in range(len(texts))]
+embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -61,7 +61,7 @@ class TestVectorStore:
 
     @pytest.fixture(scope="module")
     def db_name(self) -> str:
-        return get_env_var("DATABASE_ID", "instance for cloud sql")
+        return get_env_var("DATABASE_ID", "database name on cloud sql instance")
 
     @pytest_asyncio.fixture(scope="class")
     async def engine(self, db_project, db_region, db_instance, db_name):

--- a/tests/test_cloudsql_vectorstore_from_methods.py
+++ b/tests/test_cloudsql_vectorstore_from_methods.py
@@ -36,7 +36,7 @@ docs = [
     Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
 
-embeddings = [embeddings_service.embed_query("foo") for i in range(len(texts))]
+embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -62,7 +62,7 @@ class TestVectorStoreFromMethods:
 
     @pytest.fixture(scope="module")
     def db_name(self) -> str:
-        return get_env_var("DATABASE_ID", "instance for cloud sql")
+        return get_env_var("DATABASE_ID", "database name on cloud sql instance")
 
     @pytest_asyncio.fixture
     async def engine(self, db_project, db_region, db_instance, db_name):

--- a/tests/test_cloudsql_vectorstore_from_methods.py
+++ b/tests/test_cloudsql_vectorstore_from_methods.py
@@ -176,8 +176,6 @@ class TestVectorStoreFromMethods:
         assert results[0]["page"] is None
         assert results[0]["source"] is None
 
-        ids = [str(uuid.uuid4()) for i in range(len(texts))]
-
     async def test_afrom_docs_custom(self, engine):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         docs = [


### PR DESCRIPTION
Found a typo in docstring, referring to an old POC naming pattern.
