### PR TITLE
fix: allow special characters in table name for vector store delete 

### DIFF
--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -312,7 +312,7 @@ class PostgresVectorStore(VectorStore):
             return False
 
         id_list = ", ".join([f"'{id}'" for id in ids])
-        query = f"DELETE FROM {self.table_name} WHERE {self.id_column} in ({id_list})"
+        query = f'DELETE FROM "{self.table_name}" WHERE {self.id_column} in ({id_list})'
         await self.engine._aexecute(query)
         return True
 

--- a/tests/test_cloudsql_vectorstore.py
+++ b/tests/test_cloudsql_vectorstore.py
@@ -180,6 +180,16 @@ class TestVectorStore:
         assert len(results) == 3
         await engine._aexecute(f"TRUNCATE TABLE {DEFAULT_TABLE}")
 
+    async def test_adelete(self, engine, vs):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        await vs.aadd_texts(texts, ids=ids)
+        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        assert len(results) == 3
+        # delete an ID
+        await vs.adelete([ids[0]])
+        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        assert len(results) == 2
+
     async def test_aadd_texts_custom(self, engine, vs_custom):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs_custom.aadd_texts(texts, ids=ids)
@@ -221,6 +231,20 @@ class TestVectorStore:
         results = await engine._afetch(f'SELECT * FROM "{CUSTOM_TABLE}"')
         assert len(results) == 3
         await engine._aexecute(f'TRUNCATE TABLE "{CUSTOM_TABLE}"')
+
+    async def test_adelete_custom(self, engine, vs_custom):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        await vs_custom.aadd_texts(texts, ids=ids)
+        results = await engine._afetch(f'SELECT * FROM "{CUSTOM_TABLE}"')
+        content = [result["mycontent"] for result in results]
+        assert len(results) == 3
+        assert "foo" in content
+        # delete an ID
+        await vs_custom.adelete([ids[0]])
+        results = await engine._afetch(f'SELECT * FROM "{CUSTOM_TABLE}"')
+        content = [result["mycontent"] for result in results]
+        assert len(results) == 2
+        assert "foo" not in content
 
     async def test_add_docs(self, engine_sync, vs_sync):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]


### PR DESCRIPTION
Adding basic test for vector store `.delete` method.

Update: failing test for custom table name discovered that special characters in table name were unable to delete from the vector store.