### PR TITLE
fix: update required dep to SQLAlchemy[asyncio]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "langchain-community>=0.0.18, <0.1.0",
     "numpy>=1.24.4, <2.0.0",
     "pgvector>=0.2.5, <1.0.0",
-    "SQLAlchemy>=2.0.25, <3.0.0"
+    "SQLAlchemy[asyncio]>=2.0.25, <3.0.0"
 ]
 
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ langchain-community==0.0.28
 numpy==1.24.4; python_version<='3.8'
 numpy==1.26.4; python_version>'3.8'
 pgvector==0.2.5
-SQLAlchemy==2.0.28
+SQLAlchemy[asyncio]==2.0.28


### PR DESCRIPTION
This library uses only async SQLAlchemy connection pool engines. Thus, it should be depending on sqlalchemy[asyncio] and not just sqlalchemy.

This will fix required deps on macOS: https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#asyncio-platform-installation-notes-including-apple-m1

Port of https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/116
