### PR TITLE
refactor: return early if credentials have service account field

### DIFF
--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -59,7 +59,7 @@ async def _get_iam_principal_email(
         request = google.auth.transport.requests.Request()
         credentials.refresh(request)
     if hasattr(credentials, "_service_account_email"):
-        email = credentials._service_account_email
+        return credentials._service_account_email.replace(".gserviceaccount.com", "")
     # call OAuth2 api to get IAM principal email associated with OAuth2 token
     url = f"https://oauth2.googleapis.com/tokeninfo?access_token={credentials.token}"
     async with aiohttp.ClientSession() as client:


### PR DESCRIPTION
We should be returning early and skipping the overhead of the API call if we already know the IAM principal based on the credentials attribute. This is what we do already in the [Cloud SQL MySQL package](https://github.com/googleapis/langchain-google-cloud-sql-mysql-python/blob/main/src/langchain_google_cloud_sql_mysql/engine.py#L73).

Port of https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/117