### PR TITLE
fix: missing quote in table name

### DIFF
--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -742,7 +742,7 @@ class PostgresVectorStore(VectorStore):
         params = "WITH " + index.index_options()
         function = index.distance_strategy.index_function
         name = name or index.name
-        stmt = f'CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON "{self.table_name}" USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};'
+        stmt = f'CREATE INDEX {"CONCURRENTLY" if concurrently else ""} {name} ON "{self.table_name}" USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};'
         if concurrently:
             await self.engine._aexecute_outside_tx(stmt)
         else:

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -461,7 +461,7 @@ class PostgresVectorStore(VectorStore):
         search_function = self.distance_strategy.search_function
 
         filter = f"WHERE {filter}" if filter else ""
-        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM '{self.table_name}' {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
+        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM \"{self.table_name}\" {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
         if self.index_query_options:
             await self.engine._aexecute(
                 f"SET LOCAL {self.index_query_options.to_string()};"
@@ -742,7 +742,7 @@ class PostgresVectorStore(VectorStore):
         params = "WITH " + index.index_options()
         function = index.distance_strategy.index_function
         name = name or index.name
-        stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON '{self.table_name}' USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
+        stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON \"{self.table_name}\" USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
         if concurrently:
             await self.engine._aexecute_outside_tx(stmt)
         else:

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -461,7 +461,7 @@ class PostgresVectorStore(VectorStore):
         search_function = self.distance_strategy.search_function
 
         filter = f"WHERE {filter}" if filter else ""
-        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM '{self.table_name}' {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
+        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM \"{self.table_name}\" {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
         if self.index_query_options:
             await self.engine._aexecute(
                 f"SET LOCAL {self.index_query_options.to_string()};"
@@ -742,7 +742,7 @@ class PostgresVectorStore(VectorStore):
         params = "WITH " + index.index_options()
         function = index.distance_strategy.index_function
         name = name or index.name
-        stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON '{self.table_name}' USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
+        stmt = f'CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON "{self.table_name}" USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};'
         if concurrently:
             await self.engine._aexecute_outside_tx(stmt)
         else:

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -461,7 +461,7 @@ class PostgresVectorStore(VectorStore):
         search_function = self.distance_strategy.search_function
 
         filter = f"WHERE {filter}" if filter else ""
-        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM {self.table_name} {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
+        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM '{self.table_name}' {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
         if self.index_query_options:
             await self.engine._aexecute(
                 f"SET LOCAL {self.index_query_options.to_string()};"
@@ -742,7 +742,7 @@ class PostgresVectorStore(VectorStore):
         params = "WITH " + index.index_options()
         function = index.distance_strategy.index_function
         name = name or index.name
-        stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON {self.table_name} USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
+        stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON '{self.table_name}' USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
         if concurrently:
             await self.engine._aexecute_outside_tx(stmt)
         else:

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -461,7 +461,7 @@ class PostgresVectorStore(VectorStore):
         search_function = self.distance_strategy.search_function
 
         filter = f"WHERE {filter}" if filter else ""
-        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM \"{self.table_name}\" {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
+        stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM '{self.table_name}' {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
         if self.index_query_options:
             await self.engine._aexecute(
                 f"SET LOCAL {self.index_query_options.to_string()};"
@@ -742,7 +742,7 @@ class PostgresVectorStore(VectorStore):
         params = "WITH " + index.index_options()
         function = index.distance_strategy.index_function
         name = name or index.name
-        stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON \"{self.table_name}\" USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
+        stmt = f"CREATE INDEX {'CONCURRENTLY' if concurrently else ''} {name} ON '{self.table_name}' USING {index.index_type} ({self.embedding_column} {function}) {params} {filter};"
         if concurrently:
             await self.engine._aexecute_outside_tx(stmt)
         else:

--- a/tests/test_cloudsql_vectorstore.py
+++ b/tests/test_cloudsql_vectorstore.py
@@ -22,8 +22,8 @@ from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 
-DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
-DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4()).replace("-", "_")
+DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
+DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4())
 CUSTOM_TABLE = "test-table-custom" + str(uuid.uuid4())
 VECTOR_SIZE = 768
 

--- a/tests/test_cloudsql_vectorstore.py
+++ b/tests/test_cloudsql_vectorstore.py
@@ -94,7 +94,7 @@ class TestVectorStore:
             table_name=DEFAULT_TABLE_SYNC,
         )
         yield vs
-        engine_sync._execute(f"DROP TABLE IF EXISTS {DEFAULT_TABLE_SYNC}")
+        engine_sync._execute(f'DROP TABLE IF EXISTS "{DEFAULT_TABLE_SYNC}"')
         engine_sync._engine.dispose()
 
     @pytest_asyncio.fixture(scope="class")
@@ -106,7 +106,7 @@ class TestVectorStore:
             table_name=DEFAULT_TABLE,
         )
         yield vs
-        await engine._aexecute(f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
+        await engine._aexecute(f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
         await engine._engine.dispose()
 
     @pytest_asyncio.fixture(scope="class")
@@ -149,45 +149,45 @@ class TestVectorStore:
     async def test_aadd_texts(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_texts(texts, ids=ids)
-        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 3
 
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_texts(texts, metadatas, ids)
-        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 6
-        await engine._aexecute(f"TRUNCATE TABLE {DEFAULT_TABLE}")
+        await engine._aexecute(f'TRUNCATE TABLE "{DEFAULT_TABLE}"')
 
     async def test_aadd_texts_edge_cases(self, engine, vs):
         texts = ["Taylor's", '"Swift"', "best-friend"]
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_texts(texts, ids=ids)
-        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 3
-        await engine._aexecute(f"TRUNCATE TABLE {DEFAULT_TABLE}")
+        await engine._aexecute(f'TRUNCATE TABLE "{DEFAULT_TABLE}"')
 
     async def test_aadd_docs(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_documents(docs, ids=ids)
-        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 3
-        await engine._aexecute(f"TRUNCATE TABLE {DEFAULT_TABLE}")
+        await engine._aexecute(f'TRUNCATE TABLE "{DEFAULT_TABLE}"')
 
     async def test_aadd_embedding(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs._aadd_embeddings(texts, embeddings, metadatas, ids)
-        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 3
-        await engine._aexecute(f"TRUNCATE TABLE {DEFAULT_TABLE}")
+        await engine._aexecute(f'TRUNCATE TABLE "{DEFAULT_TABLE}"')
 
     async def test_adelete(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_texts(texts, ids=ids)
-        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 3
         # delete an ID
         await vs.adelete([ids[0]])
-        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE}")
+        results = await engine._afetch(f'SELECT * FROM "{DEFAULT_TABLE}"')
         assert len(results) == 2
 
     async def test_aadd_texts_custom(self, engine, vs_custom):
@@ -249,13 +249,13 @@ class TestVectorStore:
     async def test_add_docs(self, engine_sync, vs_sync):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         vs_sync.add_documents(docs, ids=ids)
-        results = engine_sync._fetch(f"SELECT * FROM {DEFAULT_TABLE_SYNC}")
+        results = engine_sync._fetch(f'SELECT * FROM "{DEFAULT_TABLE_SYNC}"')
         assert len(results) == 3
 
     async def test_add_texts(self, engine_sync, vs_sync):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         vs_sync.add_texts(texts, ids=ids)
-        results = engine_sync._fetch(f"SELECT * FROM {DEFAULT_TABLE_SYNC}")
+        results = engine_sync._fetch(f'SELECT * FROM "{DEFAULT_TABLE_SYNC}"')
         assert len(results) == 6
 
     # Need tests for store metadata=False


### PR DESCRIPTION
All table names should be wrapped in quotes to support special characters like dashes 