### PR TITLE
feat: Add `key` to engine constructor

### DIFF
--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -91,13 +91,19 @@ class PostgresEngine:
     """A class for managing connections to a Cloud SQL for Postgres database."""
 
     _connector: Optional[Connector] = None
+    __create_key = object()
 
     def __init__(
         self,
+        key: object,
         engine: AsyncEngine,
         loop: Optional[asyncio.AbstractEventLoop],
         thread: Optional[Thread],
     ):
+        if key != PostgresEngine.__create_key:
+            raise Exception(
+                "Only create class through 'create' or 'create_sync' methods!"
+            )
         self._engine = engine
         self._loop = loop
         self._thread = thread
@@ -191,7 +197,7 @@ class PostgresEngine:
             "postgresql+asyncpg://",
             async_creator=getconn,
         )
-        return cls(engine, loop, thread)
+        return cls(cls.__create_key, engine, loop, thread)
 
     @classmethod
     async def afrom_instance(
@@ -218,7 +224,7 @@ class PostgresEngine:
 
     @classmethod
     def from_engine(cls, engine: AsyncEngine) -> PostgresEngine:
-        return cls(engine, None, None)
+        return cls(cls.__create_key, engine, None, None)
 
     async def _aexecute(self, query: str, params: Optional[dict] = None):
         """Execute a SQL query."""

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -173,6 +173,8 @@ class TestEngineAsync:
     async def test_column(self, engine):
         with pytest.raises(ValueError):
             Column("test", VARCHAR)
+        with pytest.raises(ValueError):
+            Column(1, "INTEGER")
 
 
 @pytest.mark.asyncio
@@ -275,3 +277,11 @@ class TestEngineSync:
         assert engine
         engine._execute("SELECT 1")
         PostgresEngine._connector = None
+
+    async def test_engine_constructor_key(
+        self,
+        engine,
+    ):
+        key = object()
+        with pytest.raises(Exception):
+            PostgresEngine(key, engine)


### PR DESCRIPTION
Add key object to engine constructor to prevent constructor usage.