### PR TITLE
feat: Add similarity search score threshold select function

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,4 @@ omit =
 
 [report]
 show_missing = true
-fail_under = 83
+fail_under = 82

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -55,7 +55,6 @@ class PostgresVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ):
         if key != PostgresVectorStore.__create_key:
             raise Exception(
@@ -75,7 +74,6 @@ class PostgresVectorStore(VectorStore):
         self.fetch_k = fetch_k
         self.lambda_mult = lambda_mult
         self.index_query_options = index_query_options
-        self.relevance_score_fn = relevance_score_fn
 
     @classmethod
     async def create(
@@ -94,7 +92,6 @@ class PostgresVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ):
         """Constructor for PostgresVectorStore.
         Args:
@@ -107,7 +104,6 @@ class PostgresVectorStore(VectorStore):
             ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
-            relevance_score_fn (Callable): custom function to overrides default relevance score calculation functions.
         """
         if metadata_columns and ignore_metadata_columns:
             raise ValueError(
@@ -172,7 +168,6 @@ class PostgresVectorStore(VectorStore):
             fetch_k,
             lambda_mult,
             index_query_options,
-            relevance_score_fn,
         )
 
     @classmethod
@@ -192,7 +187,6 @@ class PostgresVectorStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         index_query_options: Optional[QueryOptions] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
     ):
         coro = cls.create(
             engine,
@@ -209,7 +203,6 @@ class PostgresVectorStore(VectorStore):
             fetch_k,
             lambda_mult,
             index_query_options,
-            relevance_score_fn,
         )
         return engine._run_as_sync(coro)
 
@@ -505,9 +498,6 @@ class PostgresVectorStore(VectorStore):
         """
         Select a relevance function based on distance strategy
         """
-        if self.relevance_score_fn is not None:
-            return self.relevance_score_fn
-
         # Calculate distance strategy provided in
         # vectorstore constructor
         if self.distance_strategy == DistanceStrategy.COSINE_DISTANCE:

--- a/tests/test_cloudsql_vectorstore_search.py
+++ b/tests/test_cloudsql_vectorstore_search.py
@@ -151,6 +151,14 @@ class TestVectorStoreSearch:
         assert results[0][0] == Document(page_content="foo")
         assert results[0][1] == 0
 
+    async def test_similarity_search_with_relevance_scores_threshold(self, vs):
+        score_threshold = {"score_threshold": 0.9}
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "foo", **score_threshold
+        )
+        assert len(results) == 1
+        assert results[0][0] == Document(page_content="foo")
+
     async def test_amax_marginal_relevance_search(self, vs):
         results = await vs.amax_marginal_relevance_search("bar")
         assert results[0] == Document(page_content="bar")

--- a/tests/test_cloudsql_vectorstore_search.py
+++ b/tests/test_cloudsql_vectorstore_search.py
@@ -152,6 +152,18 @@ class TestVectorStoreSearch:
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold(self, vs):
+        score_threshold = {"score_threshold": 0}
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "foo", **score_threshold
+        )
+        assert len(results) == 4
+
+        score_threshold = {"score_threshold": 0.02}
+        results = await vs.asimilarity_search_with_relevance_scores(
+            "foo", **score_threshold
+        )
+        assert len(results) == 2
+
         score_threshold = {"score_threshold": 0.9}
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold


### PR DESCRIPTION
Implements LangChain `_select_relevance_score_fn` function to support similarity search with score threshold: https://github.com/langchain-ai/langchain/blob/cb95198398a66737f1a7f7e0f63417802e03190c/libs/core/langchain_core/vectorstores/base.py#L611
