### PR TITLE
feat: Add table name to default index name

### DIFF
--- a/src/langchain_google_cloud_sql_pg/indexes.py
+++ b/src/langchain_google_cloud_sql_pg/indexes.py
@@ -34,12 +34,12 @@ class DistanceStrategy(StrategyMixin, enum.Enum):
 
 
 DEFAULT_DISTANCE_STRATEGY = DistanceStrategy.COSINE_DISTANCE
-DEFAULT_INDEX_NAME = "langchainvectorindex"
+DEFAULT_INDEX_NAME_SUFFIX: str = "langchainvectorindex"
 
 
 @dataclass
 class BaseIndex(ABC):
-    name: str = DEFAULT_INDEX_NAME
+    name: Optional[str] = None
     index_type: str = "base"
     distance_strategy: DistanceStrategy = field(
         default_factory=lambda: DistanceStrategy.COSINE_DISTANCE

--- a/tests/test_cloudsql_vectorstore_index.py
+++ b/tests/test_cloudsql_vectorstore_index.py
@@ -24,7 +24,7 @@ from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_pg import PostgresEngine, PostgresVectorStore
 from langchain_google_cloud_sql_pg.indexes import (
-    DEFAULT_INDEX_NAME,
+    DEFAULT_INDEX_NAME_SUFFIX,
     DistanceStrategy,
     HNSWIndex,
     IVFFlatIndex,
@@ -32,6 +32,7 @@ from langchain_google_cloud_sql_pg.indexes import (
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
+DEFAULT_INDEX_NAME = DEFAULT_TABLE + DEFAULT_INDEX_NAME_SUFFIX
 VECTOR_SIZE = 768
 
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)


### PR DESCRIPTION
Add table name as prefix to default index name upon index creation to avoid conflicting default index names for different tables.

1. Change `DEFAULT_INDEX_NAME` to `DEFAULT_INDEX_NAME_SUFFIX`.
2. Change `index_name` default in the `BaseIndex` class to `None`.
3. In `aapply_vector_index()`, check if the index_name field is `None` and if so, give it a default index name (table_name + DEFAULT_INDEX_NAME_SUFFIX).