### PR TITLE
feat: Remove langchain-community dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
 dependencies = [
     "cloud-sql-python-connector[asyncpg] >= 1.10.0, <2.0.0",
     "langchain-core>=0.1.1, <1.0.0 ",
-    "langchain-community>=0.0.18, <0.3.0",
     "numpy>=1.24.4, <2.0.0",
     "pgvector>=0.2.5, <1.0.0",
     "SQLAlchemy[asyncio]>=2.0.25, <3.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cloud-sql-python-connector[asyncpg]==1.10.0
 langchain-core==0.2.12
-langchain-community==0.2.6
 numpy===1.24.4; python_version<='3.8'
 numpy==1.26.4; python_version>'3.8'
 pgvector==0.3.0

--- a/samples/requirements.txt
+++ b/samples/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-aiplatform[reasoningengine,langchain]
 langchain-google-vertexai
-langchain
+langchain-community
 google-cloud-resource-manager

--- a/src/langchain_google_cloud_sql_pg/loader.py
+++ b/src/langchain_google_cloud_sql_pg/loader.py
@@ -27,7 +27,7 @@ from typing import (
 )
 
 import sqlalchemy
-from langchain_community.document_loaders.base import BaseLoader
+from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 
 from .engine import PostgresEngine

--- a/tests/test_cloudsql_vectorstore.py
+++ b/tests/test_cloudsql_vectorstore.py
@@ -17,7 +17,7 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_community.embeddings import DeterministicFakeEmbedding
+from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore

--- a/tests/test_cloudsql_vectorstore.py
+++ b/tests/test_cloudsql_vectorstore.py
@@ -17,8 +17,8 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 

--- a/tests/test_cloudsql_vectorstore_from_methods.py
+++ b/tests/test_cloudsql_vectorstore_from_methods.py
@@ -17,7 +17,7 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_community.embeddings import DeterministicFakeEmbedding
+from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore

--- a/tests/test_cloudsql_vectorstore_from_methods.py
+++ b/tests/test_cloudsql_vectorstore_from_methods.py
@@ -17,8 +17,8 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 

--- a/tests/test_cloudsql_vectorstore_index.py
+++ b/tests/test_cloudsql_vectorstore_index.py
@@ -19,8 +19,8 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding
 
 from langchain_google_cloud_sql_pg import PostgresEngine, PostgresVectorStore
 from langchain_google_cloud_sql_pg.indexes import (

--- a/tests/test_cloudsql_vectorstore_index.py
+++ b/tests/test_cloudsql_vectorstore_index.py
@@ -19,7 +19,7 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_community.embeddings import DeterministicFakeEmbedding
+from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_pg import PostgresEngine, PostgresVectorStore

--- a/tests/test_cloudsql_vectorstore_search.py
+++ b/tests/test_cloudsql_vectorstore_search.py
@@ -17,8 +17,8 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 from langchain_google_cloud_sql_pg.indexes import HNSWQueryOptions, IVFFlatQueryOptions

--- a/tests/test_cloudsql_vectorstore_search.py
+++ b/tests/test_cloudsql_vectorstore_search.py
@@ -17,7 +17,7 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from langchain_community.embeddings import DeterministicFakeEmbedding
+from langchain_core.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -19,7 +19,7 @@ import asyncpg  # type: ignore
 import pytest
 import pytest_asyncio
 from google.cloud.sql.connector import Connector, IPTypes
-from langchain_community.embeddings import DeterministicFakeEmbedding
+from langchain_core.embeddings import DeterministicFakeEmbedding
 from sqlalchemy import VARCHAR
 from sqlalchemy.ext.asyncio import create_async_engine
 


### PR DESCRIPTION
We choose langchain-core as the langchain library to use for this repo. This PR removes denpendency on langchain-community and replaces APIs with corresponding ones from langchain-core.