### PR TITLE
fix: add support for cross environment usage

### DIFF
--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -323,7 +323,12 @@ class PostgresEngine:
     @classmethod
     def from_engine(cls, engine: AsyncEngine) -> PostgresEngine:
         """Create an PostgresEngine instance from an AsyncEngine."""
-        loop = asyncio.get_event_loop()
+        # loop = asyncio.get_event_loop()
+        # try:
+        #     loop = asyncio.get_running_loop()
+        #     thread = None
+        # except RuntimeError:  # If no running loop
+        loop = asyncio.new_event_loop()
         thread = Thread(target=loop.run_forever, daemon=True)
         thread.start()
         return cls(cls.__create_key, engine, loop, thread)

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -176,10 +176,10 @@ class PostgresEngine:
             instance,
             database,
             ip_type,
-            user,
-            password,
-            loop=loop,
-            thread=thread,
+            loop,
+            thread,
+            user=user,
+            password=password,
             quota_project=quota_project,
             iam_account_email=iam_account_email,
         )
@@ -316,40 +316,9 @@ class PostgresEngine:
             quota_project=quota_project,
             iam_account_email=iam_account_email,
         )
-
         future = asyncio.run_coroutine_threadsafe(coro, loop)
         task = asyncio.wrap_future(future)
         return await task
-
-    @classmethod
-    def from_instance(
-        cls,
-        project_id: str,
-        region: str,
-        instance: str,
-        database: str,
-        ip_type: Union[str, IPTypes] = IPTypes.PUBLIC,
-        user: Optional[str] = None,
-        password: Optional[str] = None,
-        quota_project: Optional[str] = None,
-    ) -> PostgresEngine:
-        loop = asyncio.new_event_loop()
-        thread = Thread(target=loop.run_forever, daemon=True)
-        thread.start()
-
-        coro = cls._create_engine(
-            project_id,
-            region,
-            instance,
-            database,
-            ip_type,
-            loop,
-            thread,
-            user=user,
-            password=password,
-            quota_project=quota_project,
-        )
-        return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
     @classmethod
     def from_engine(cls, engine: AsyncEngine) -> PostgresEngine:

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -373,14 +373,10 @@ class PostgresEngine:
             await conn.execute(text(query), params)
             await conn.commit()
 
-    # async def _aexecute_outside_tx(self, query: str):
-    #     future = asyncio.run_coroutine_threadsafe(
-    #         self.__aexecute_outside_tx(query), self._loop
-    #     )
-    #     task = asyncio.wrap_future(future)
-    #     await task
-
     async def _aexecute_outside_tx(self, query: str):
+        return await self._run_on_loop(self.__aexecute_outside_tx(query))
+
+    async def __aexecute_outside_tx(self, query: str):
         """Execute a SQL query."""
         async with self._engine.connect() as conn:
             await conn.execute(text("COMMIT"))
@@ -649,6 +645,12 @@ class PostgresEngine:
         )
 
     async def _aload_table_schema(
+        self,
+        table_name: str,
+    ) -> Table:
+        return await self._run_on_loop(self.__aload_table_schema(table_name))
+
+    async def __aload_table_schema(
         self,
         table_name: str,
     ) -> Table:

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -332,15 +332,15 @@ class PostgresEngine:
         """Execute a SQL query."""
         return await self._run_on_loop(self.__aexecute(query, params))
 
-    async def __aexecute(self, query: str, params: Optional[dict] = None):
+    async def __aexecute(self, query: str, params: Optional[dict] = None) -> None:
         async with self._engine.connect() as conn:
             await conn.execute(text(query), params)
             await conn.commit()
 
-    async def _aexecute_outside_tx(self, query: str):
+    async def _aexecute_outside_tx(self, query: str) -> None:
         return await self._run_on_loop(self.__aexecute_outside_tx(query))
 
-    async def __aexecute_outside_tx(self, query: str):
+    async def __aexecute_outside_tx(self, query: str) -> None:
         """Execute a SQL query."""
         async with self._engine.connect() as conn:
             await conn.execute(text("COMMIT"))
@@ -352,7 +352,9 @@ class PostgresEngine:
         """Fetch results from a SQL query."""
         return await self._run_on_loop(self.__afetch(query, params))
 
-    async def __afetch(self, query: str, params: Optional[dict] = None):
+    async def __afetch(
+        self, query: str, params: Optional[dict] = None
+    ) -> Sequence[RowMapping]:
         async with self._engine.connect() as conn:
             result = await conn.execute(text(query), params)
             result_map = result.mappings()

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -323,11 +323,6 @@ class PostgresEngine:
     @classmethod
     def from_engine(cls, engine: AsyncEngine) -> PostgresEngine:
         """Create an PostgresEngine instance from an AsyncEngine."""
-        # loop = asyncio.get_event_loop()
-        # try:
-        #     loop = asyncio.get_running_loop()
-        #     thread = None
-        # except RuntimeError:  # If no running loop
         loop = asyncio.new_event_loop()
         thread = Thread(target=loop.run_forever, daemon=True)
         thread.start()

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -37,7 +37,6 @@ from sqlalchemy import MetaData, Table, text
 from sqlalchemy.engine.row import RowMapping
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from sqlalchemy.pool import NullPool
 
 from .version import __version__
 
@@ -267,7 +266,7 @@ class PostgresEngine:
 
         engine = create_async_engine(
             "postgresql+asyncpg://",
-            async_creator=getconn,  # poolclass=NullPool
+            async_creator=getconn,
         )
         return cls(cls.__create_key, engine, loop, thread)
 
@@ -417,35 +416,6 @@ class PostgresEngine:
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
         task = asyncio.wrap_future(future)
         return await task
-
-    # async def ainit_vectorstore_table(
-    #     self,
-    #     table_name: str,
-    #     vector_size: int,
-    #     content_column: str = "content",
-    #     embedding_column: str = "embedding",
-    #     metadata_columns: List[Column] = [],
-    #     metadata_json_column: str = "langchain_metadata",
-    #     id_column: str = "langchain_id",
-    #     overwrite_existing: bool = False,
-    #     store_metadata: bool = True,
-    # ) -> None:
-    #     future = asyncio.run_coroutine_threadsafe(
-    #         self.__ainit_vectorstore_table(
-    #             table_name,
-    #             vector_size,
-    #             content_column,
-    #             embedding_column,
-    #             metadata_columns,
-    #             metadata_json_column,
-    #             id_column,
-    #             overwrite_existing,
-    #             store_metadata,
-    #         ),
-    #         self._loop,
-    #     )
-    #     task = asyncio.wrap_future(future)
-    #     await task
 
     async def ainit_vectorstore_table(
         self,
@@ -651,46 +621,6 @@ class PostgresEngine:
         table_name: str,
     ) -> Table:
         return await self._run_on_loop(self.__aload_table_schema(table_name))
-
-    # async def _aload_table_schema(
-    #     self,
-    #     table_name: str,
-    # ) -> List[str]:
-    #     """
-    #     Load table schema from existing table in PgSQL database.
-    #     Returns:
-    #         (sqlalchemy.Table): The loaded table.
-    #     """
-    #     query = f"""
-    #     SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT
-    #     FROM INFORMATION_SCHEMA.COLUMNS
-    #     WHERE table_name = '{table_name}';
-    #     """
-    #     results = await self._afetch(query)
-    #     return results
-    # metadata = MetaData()
-    # async with self._engine.connect() as conn:
-    #     try:
-    #         await conn.run_sync(metadata.reflect, only=[table_name])
-    #     except InvalidRequestError as e:
-    #         raise ValueError(
-    #             f"Table, {table_name}, does not exist: " + str(e)
-    #         )
-
-    # table = Table(table_name, metadata)
-    # # Extract the schema information
-    # schema = []
-    # for column in table.columns:
-    #     schema.append(
-    #         {
-    #             "name": column.name,
-    #             "type": column.type.python_type,
-    #             "max_length": getattr(column.type, "length", None),
-    #             "nullable": not column.nullable,
-    #         }
-    #     )
-
-    # return metadata.tables[table_name]
 
     async def __aload_table_schema(
         self,

--- a/src/langchain_google_cloud_sql_pg/loader.py
+++ b/src/langchain_google_cloud_sql_pg/loader.py
@@ -314,14 +314,8 @@ class PostgresLoader(BaseLoader):
 
     def load(self) -> List[Document]:
         """Load PostgreSQL data into Document objects."""
-        # documents = self.engine._run_as_sync(
-        #     self._collect_async_items(self.alazy_load())
-        # )
         documents = self.engine._run_as_sync(self.aload())
         return documents
-
-    # async def aload(self) -> List[Document]:
-    #     return await self.engine._run_on_loop(self._aload())
 
     async def aload(self) -> List[Document]:
         """Load PostgreSQL data into Document objects."""
@@ -333,14 +327,8 @@ class PostgresLoader(BaseLoader):
             self._collect_async_items(self.alazy_load())
         )
 
-    # async def alazy_load(self) -> AsyncIterator[Document]:
-    #     return await self.engine._run_on_loop(self.alazy_load())
-
     async def alazy_load(self) -> AsyncIterator[Document]:
         """Load PostgreSQL data into Document objects lazily."""
-        # stmt = sqlalchemy.text(self.query)
-        # async with self.engine._engine.connect() as connection:
-        #     result_proxy = await connection.execute(stmt)
         # load document one by one
         result_proxy = await self.engine._afetchone(self.query)
         while True:

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -60,7 +60,9 @@ class TestEngineSync:
         return get_env_var("DB_PASSWORD", "database password for cloud sql")
 
     @pytest_asyncio.fixture
-    def memory_engine(self, project_id, region, instance_id, db_name) -> Generator:
+    def memory_engine(
+        self, project_id: str, region: str, instance_id: str, db_name: str
+    ) -> Generator:
         engine = PostgresEngine.from_instance(
             project_id=project_id,
             region=region,
@@ -72,7 +74,8 @@ class TestEngineSync:
         # use default table for PostgresChatMessageHistory
         query = f'DROP TABLE IF EXISTS "{table_name}"'
         engine._execute(query)
-        engine._run_as_sync(engine._connector.close_async())
+        if engine._connector:
+            engine._run_as_sync(engine._connector.close_async())
         engine._run_as_sync(engine._engine.dispose())
 
     def test_chat_message_history(self, memory_engine: PostgresEngine) -> None:
@@ -168,7 +171,9 @@ class TestEngineAsync:
         return get_env_var("DB_PASSWORD", "database password for cloud sql")
 
     @pytest_asyncio.fixture
-    async def async_engine(self, project_id, region, instance_id, db_name):
+    async def async_engine(
+        self, project_id: str, region: str, instance_id: str, db_name: str
+    ) -> Generator:
         engine = await PostgresEngine.afrom_instance(
             project_id=project_id,
             region=region,
@@ -179,7 +184,8 @@ class TestEngineAsync:
         yield engine
 
         await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name_async}"')
-        await engine._connector.close_async()
+        if engine._connector:
+            await engine._connector.close_async()
         await engine._engine.dispose()
 
     @pytest.mark.asyncio

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -20,150 +20,267 @@ import pytest_asyncio
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.human import HumanMessage
 
-from langchain_google_cloud_sql_pg import PostgresChatMessageHistory, PostgresEngine
+from langchain_google_cloud_sql_pg import (
+    PostgresChatMessageHistory,
+    PostgresEngine,
+)
 
-project_id = os.environ["PROJECT_ID"]
-region = os.environ["REGION"]
-instance_id = os.environ["INSTANCE_ID"]
-db_name = os.environ["DATABASE_ID"]
 table_name = "message_store" + str(uuid.uuid4())
 table_name_async = "message_store" + str(uuid.uuid4())
 
 
-@pytest.fixture(name="memory_engine")
-def setup() -> Generator:
-    engine = PostgresEngine.from_instance(
-        project_id=project_id,
-        region=region,
-        instance=instance_id,
-        database=db_name,
-    )
-    engine.init_chat_history_table(table_name=table_name)
-    yield engine
-    # use default table for PostgresChatMessageHistory
-    query = f'DROP TABLE IF EXISTS "{table_name}"'
-    engine._execute(query)
+def get_env_var(key: str, desc: str) -> str:
+    v = os.environ.get(key)
+    if v is None:
+        raise ValueError(f"Must set env var {key} to: {desc}")
+    return v
 
 
-@pytest_asyncio.fixture
-async def async_engine():
-    engine = await PostgresEngine.afrom_instance(
-        project_id=project_id,
-        region=region,
-        instance=instance_id,
-        database=db_name,
-    )
-    await engine.ainit_chat_history_table(table_name=table_name_async)
-    yield engine
-    # use default table for PostgresChatMessageHistory
-    query = f'DROP TABLE IF EXISTS "{table_name}"'
-    await engine._aexecute(query)
+@pytest.mark.asyncio
+class TestEngineSync:
+    @pytest.fixture(scope="module")
+    def project_id(self) -> str:
+        return get_env_var("PROJECT_ID", "project id for google cloud")
 
+    @pytest.fixture(scope="module")
+    def region(self) -> str:
+        return get_env_var("REGION", "region for cloud sql instance")
 
-def test_chat_message_history(memory_engine: PostgresEngine) -> None:
-    history = PostgresChatMessageHistory.create_sync(
-        engine=memory_engine, session_id="test", table_name=table_name
-    )
-    history.add_user_message("hi!")
-    history.add_ai_message("whats up?")
-    messages = history.messages
+    @pytest.fixture(scope="module")
+    def instance_id(self) -> str:
+        return get_env_var("INSTANCE_ID", "instance for cloud sql")
 
-    # verify messages are correct
-    assert messages[0].content == "hi!"
-    assert type(messages[0]) is HumanMessage
-    assert messages[1].content == "whats up?"
-    assert type(messages[1]) is AIMessage
+    @pytest.fixture(scope="module")
+    def db_name(self) -> str:
+        return get_env_var("DATABASE_ID", "instance for cloud sql")
 
-    # verify clear() clears message history
-    history.clear()
-    assert len(history.messages) == 0
+    @pytest.fixture(scope="module")
+    def user(self) -> str:
+        return get_env_var("DB_USER", "database user for cloud sql")
 
+    @pytest.fixture(scope="module")
+    def password(self) -> str:
+        return get_env_var("DB_PASSWORD", "database password for cloud sql")
 
-def test_chat_table(memory_engine: Any) -> None:
-    with pytest.raises(ValueError):
-        PostgresChatMessageHistory.create_sync(
-            engine=memory_engine, session_id="test", table_name="doesnotexist"
+    @pytest_asyncio.fixture
+    def memory_engine(
+        self, project_id, region, instance_id, db_name
+    ) -> Generator:
+        engine = PostgresEngine.from_instance(
+            project_id=project_id,
+            region=region,
+            instance=instance_id,
+            database=db_name,
         )
+        engine.init_chat_history_table(table_name=table_name)
+        yield engine
+        # use default table for PostgresChatMessageHistory
+        query = f'DROP TABLE IF EXISTS "{table_name}"'
+        engine._execute(query)
+        engine._run_as_sync(engine._connector.close_async())
+        engine._run_as_sync(engine._engine.dispose())
 
-
-def test_chat_schema(memory_engine: Any) -> None:
-    doc_table_name = "test_table" + str(uuid.uuid4())
-    memory_engine.init_document_table(table_name=doc_table_name)
-    with pytest.raises(IndexError):
-        PostgresChatMessageHistory.create_sync(
-            engine=memory_engine, session_id="test", table_name=doc_table_name
+    def test_chat_message_history(self, memory_engine: PostgresEngine) -> None:
+        history = PostgresChatMessageHistory.create_sync(
+            engine=memory_engine, session_id="test", table_name=table_name
         )
+        history.add_user_message("hi!")
+        history.add_ai_message("whats up?")
+        messages = history.messages
 
-    query = f'DROP TABLE IF EXISTS "{doc_table_name}"'
-    memory_engine._execute(query)
+        # verify messages are correct
+        assert messages[0].content == "hi!"
+        assert type(messages[0]) is HumanMessage
+        assert messages[1].content == "whats up?"
+        assert type(messages[1]) is AIMessage
 
+        # verify clear() clears message history
+        history.clear()
+        assert len(history.messages) == 0
 
-@pytest.mark.asyncio
-async def test_chat_message_history_async(
-    async_engine: PostgresEngine,
-) -> None:
-    history = await PostgresChatMessageHistory.create(
-        engine=async_engine, session_id="test", table_name=table_name_async
-    )
-    msg1 = HumanMessage(content="hi!")
-    msg2 = AIMessage(content="whats up?")
-    await history.aadd_message(msg1)
-    await history.aadd_message(msg2)
-    messages = history.messages
-
-    # verify messages are correct
-    assert messages[0].content == "hi!"
-    assert type(messages[0]) is HumanMessage
-    assert messages[1].content == "whats up?"
-    assert type(messages[1]) is AIMessage
-
-    # verify clear() clears message history
-    await history.aclear()
-    assert len(history.messages) == 0
-
-
-@pytest.mark.asyncio
-async def test_chat_message_history_sync_messages(
-    async_engine: PostgresEngine,
-) -> None:
-    history1 = await PostgresChatMessageHistory.create(
-        engine=async_engine, session_id="test", table_name=table_name_async
-    )
-    history2 = await PostgresChatMessageHistory.create(
-        engine=async_engine, session_id="test", table_name=table_name_async
-    )
-    msg1 = HumanMessage(content="hi!")
-    msg2 = AIMessage(content="whats up?")
-    await history1.aadd_message(msg1)
-    await history2.aadd_message(msg2)
-
-    assert len(history1.messages) == 1
-    assert len(history2.messages) == 2
-
-    await history1.async_messages()
-    assert len(history1.messages) == 2
-
-    # verify clear() clears message history
-    await history2.aclear()
-    assert len(history2.messages) == 0
-
-
-@pytest.mark.asyncio
-async def test_chat_table_async(async_engine):
-    with pytest.raises(ValueError):
-        await PostgresChatMessageHistory.create(
-            engine=async_engine, session_id="test", table_name="doesnotexist"
+    @pytest.mark.asyncio
+    async def test_cross_env_chat_message_history(
+        self, memory_engine: PostgresEngine
+    ):
+        history = PostgresChatMessageHistory.create_sync(
+            engine=memory_engine, session_id="test", table_name=table_name
         )
+        await history.aadd_message(HumanMessage(content="hi!"))
+        messages = history.messages
+        assert messages[0].content == "hi!"
+        history.clear()
+
+    def test_chat_table(self, memory_engine: PostgresEngine):
+        with pytest.raises(ValueError):
+            PostgresChatMessageHistory.create_sync(
+                engine=memory_engine,
+                session_id="test",
+                table_name="doesnotexist",
+            )
+
+    def test_chat_schema(self, memory_engine: PostgresEngine):
+        doc_table_name = "test_table" + str(uuid.uuid4())
+        memory_engine.init_document_table(table_name=doc_table_name)
+        with pytest.raises(IndexError):
+            PostgresChatMessageHistory.create_sync(
+                engine=memory_engine,
+                session_id="test",
+                table_name=doc_table_name,
+            )
+
+        memory_engine._execute(f'DROP TABLE IF EXISTS "{doc_table_name}"')
+
+    @pytest.mark.asyncio
+    async def test_cross_env_sync_engine(self, memory_engine: PostgresEngine):
+        history = PostgresChatMessageHistory.create_sync(
+            engine=memory_engine, session_id="test", table_name=table_name
+        )
+        await history.aadd_message(HumanMessage(content="hi!"))
+        messages = history.messages
+        assert messages[0].content == "hi!"
+        await history.aclear()
+
+        history.add_message(HumanMessage(content="hi!"))
+        messages = history.messages
+        assert messages[0].content == "hi!"
+        history.clear()
 
 
 @pytest.mark.asyncio
-async def test_chat_schema_async(async_engine):
-    table_name = "test_table" + str(uuid.uuid4())
-    await async_engine.ainit_document_table(table_name=table_name)
-    with pytest.raises(IndexError):
-        await PostgresChatMessageHistory.create(
+class TestEngineAsync:
+    @pytest.fixture(scope="module")
+    def project_id(self) -> str:
+        return get_env_var("PROJECT_ID", "project id for google cloud")
+
+    @pytest.fixture(scope="module")
+    def region(self) -> str:
+        return get_env_var("REGION", "region for cloud sql instance")
+
+    @pytest.fixture(scope="module")
+    def instance_id(self) -> str:
+        return get_env_var("INSTANCE_ID", "instance for cloud sql")
+
+    @pytest.fixture(scope="module")
+    def db_name(self) -> str:
+        return get_env_var("DATABASE_ID", "instance for cloud sql")
+
+    @pytest.fixture(scope="module")
+    def user(self) -> str:
+        return get_env_var("DB_USER", "database user for cloud sql")
+
+    @pytest.fixture(scope="module")
+    def password(self) -> str:
+        return get_env_var("DB_PASSWORD", "database password for cloud sql")
+
+    @pytest_asyncio.fixture
+    async def async_engine(self, project_id, region, instance_id, db_name):
+        engine = await PostgresEngine.afrom_instance(
+            project_id=project_id,
+            region=region,
+            instance=instance_id,
+            database=db_name,
+        )
+        await engine.ainit_chat_history_table(table_name=table_name_async)
+        yield engine
+
+        await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
+        await engine._connector.close_async()
+        await engine._engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_cross_env_engine(self, async_engine: PostgresEngine):
+        history = PostgresChatMessageHistory.create_sync(
             engine=async_engine, session_id="test", table_name=table_name
         )
+        await history.aadd_message(HumanMessage(content="hi!"))
+        messages = history.messages
+        assert messages[0].content == "hi!"
+        await history.aclear()
 
-    query = f'DROP TABLE IF EXISTS "{table_name}"'
-    await async_engine._aexecute(query)
+        history.add_message(HumanMessage(content="hi!"))
+        messages = history.messages
+        assert messages[0].content == "hi!"
+        history.clear()
+
+    @pytest.mark.asyncio
+    async def test_chat_message_history_async(
+        self,
+        async_engine: PostgresEngine,
+    ) -> None:
+        history = await PostgresChatMessageHistory.create(
+            engine=async_engine, session_id="test", table_name=table_name_async
+        )
+        msg1 = HumanMessage(content="hi!")
+        msg2 = AIMessage(content="whats up?")
+        await history.aadd_message(msg1)
+        await history.aadd_message(msg2)
+        messages = history.messages
+
+        # verify messages are correct
+        assert messages[0].content == "hi!"
+        assert type(messages[0]) is HumanMessage
+        assert messages[1].content == "whats up?"
+        assert type(messages[1]) is AIMessage
+
+        # verify clear() clears message history
+        await history.aclear()
+        assert len(history.messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_chat_message_history_sync_messages(
+        self,
+        async_engine: PostgresEngine,
+    ) -> None:
+        history1 = await PostgresChatMessageHistory.create(
+            engine=async_engine, session_id="test", table_name=table_name_async
+        )
+        history2 = await PostgresChatMessageHistory.create(
+            engine=async_engine, session_id="test", table_name=table_name_async
+        )
+        msg1 = HumanMessage(content="hi!")
+        msg2 = AIMessage(content="whats up?")
+        await history1.aadd_message(msg1)
+        await history2.aadd_message(msg2)
+
+        assert len(history1.messages) == 1
+        assert len(history2.messages) == 2
+
+        await history1.async_messages()
+        assert len(history1.messages) == 2
+
+        # verify clear() clears message history
+        await history2.aclear()
+        assert len(history2.messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_cross_env(
+        self,
+        async_engine: PostgresEngine,
+    ) -> None:
+        history = await PostgresChatMessageHistory.create(
+            engine=async_engine, session_id="test", table_name=table_name_async
+        )
+        history.add_message(HumanMessage(content="hi!"))
+        messages = history.messages
+        assert messages[0].content == "hi!"
+        history.clear()
+
+    @pytest.mark.asyncio
+    async def test_chat_table_async(self, async_engine: PostgresEngine):
+        with pytest.raises(ValueError):
+            await PostgresChatMessageHistory.create(
+                engine=async_engine,
+                session_id="test",
+                table_name="doesnotexist",
+            )
+
+    @pytest.mark.asyncio
+    async def test_chat_schema_async(self, async_engine: PostgresEngine):
+        table_name = "test_table" + str(uuid.uuid4())
+        await async_engine.ainit_document_table(table_name=table_name)
+        with pytest.raises(IndexError):
+            await PostgresChatMessageHistory.create(
+                engine=async_engine, session_id="test", table_name=table_name
+            )
+
+        await async_engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -23,7 +23,10 @@ from langchain_core.messages.human import HumanMessage
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 
-from langchain_google_cloud_sql_pg import PostgresChatMessageHistory, PostgresEngine
+from langchain_google_cloud_sql_pg import (
+    PostgresChatMessageHistory,
+    PostgresEngine,
+)
 
 table_name = "message_store" + str(uuid.uuid4())
 table_name_async = "message_store" + str(uuid.uuid4())
@@ -298,7 +301,7 @@ class TestEngineAsync:
         db_name: str,
         user: str,
         password: str,
-    ):
+    ) -> None:
         async def init_connection_pool(connector: Connector):
             async def getconn():
                 conn = await connector.connect_async(

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -176,14 +176,14 @@ class TestEngineAsync:
         await engine.ainit_chat_history_table(table_name=table_name_async)
         yield engine
 
-        await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
+        await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name_async}"')
         await engine._connector.close_async()
         await engine._engine.dispose()
 
     @pytest.mark.asyncio
     async def test_cross_env_engine(self, async_engine: PostgresEngine):
         history = PostgresChatMessageHistory.create_sync(
-            engine=async_engine, session_id="test", table_name=table_name
+            engine=async_engine, session_id="test", table_name=table_name_async
         )
         await history.aadd_message(HumanMessage(content="hi!"))
         messages = history.messages

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -21,6 +21,7 @@ from google.cloud.sql.connector import Connector, create_async_connector
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.human import HumanMessage
 from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
 
 from langchain_google_cloud_sql_pg import PostgresChatMessageHistory, PostgresEngine
 
@@ -314,6 +315,7 @@ class TestEngineAsync:
             pool = create_async_engine(
                 "postgresql+asyncpg://",
                 async_creator=getconn,
+                poolclass=NullPool,
             )
             return pool
 

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -20,10 +20,7 @@ import pytest_asyncio
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.human import HumanMessage
 
-from langchain_google_cloud_sql_pg import (
-    PostgresChatMessageHistory,
-    PostgresEngine,
-)
+from langchain_google_cloud_sql_pg import PostgresChatMessageHistory, PostgresEngine
 
 table_name = "message_store" + str(uuid.uuid4())
 table_name_async = "message_store" + str(uuid.uuid4())
@@ -63,9 +60,7 @@ class TestEngineSync:
         return get_env_var("DB_PASSWORD", "database password for cloud sql")
 
     @pytest_asyncio.fixture
-    def memory_engine(
-        self, project_id, region, instance_id, db_name
-    ) -> Generator:
+    def memory_engine(self, project_id, region, instance_id, db_name) -> Generator:
         engine = PostgresEngine.from_instance(
             project_id=project_id,
             region=region,
@@ -99,9 +94,7 @@ class TestEngineSync:
         assert len(history.messages) == 0
 
     @pytest.mark.asyncio
-    async def test_cross_env_chat_message_history(
-        self, memory_engine: PostgresEngine
-    ):
+    async def test_cross_env_chat_message_history(self, memory_engine: PostgresEngine):
         history = PostgresChatMessageHistory.create_sync(
             engine=memory_engine, session_id="test", table_name=table_name
         )

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 import uuid
-from typing import Any, Generator
+from typing import Any, AsyncGenerator, Generator
 
 import pytest
 import pytest_asyncio
@@ -173,7 +173,7 @@ class TestEngineAsync:
     @pytest_asyncio.fixture
     async def async_engine(
         self, project_id: str, region: str, instance_id: str, db_name: str
-    ) -> Generator:
+    ) -> AsyncGenerator:
         engine = await PostgresEngine.afrom_instance(
             project_id=project_id,
             region=region,

--- a/tests/test_postgresql_chatmessagehistory.py
+++ b/tests/test_postgresql_chatmessagehistory.py
@@ -94,7 +94,9 @@ class TestEngineSync:
         assert len(history.messages) == 0
 
     @pytest.mark.asyncio
-    async def test_cross_env_chat_message_history(self, memory_engine: PostgresEngine):
+    async def test_cross_env_chat_message_history(
+        self, memory_engine: PostgresEngine
+    ) -> None:
         history = PostgresChatMessageHistory.create_sync(
             engine=memory_engine, session_id="test", table_name=table_name
         )
@@ -103,7 +105,7 @@ class TestEngineSync:
         assert messages[0].content == "hi!"
         history.clear()
 
-    def test_chat_table(self, memory_engine: PostgresEngine):
+    def test_chat_table(self, memory_engine: PostgresEngine) -> None:
         with pytest.raises(ValueError):
             PostgresChatMessageHistory.create_sync(
                 engine=memory_engine,
@@ -111,7 +113,7 @@ class TestEngineSync:
                 table_name="doesnotexist",
             )
 
-    def test_chat_schema(self, memory_engine: PostgresEngine):
+    def test_chat_schema(self, memory_engine: PostgresEngine) -> None:
         doc_table_name = "test_table" + str(uuid.uuid4())
         memory_engine.init_document_table(table_name=doc_table_name)
         with pytest.raises(IndexError):
@@ -124,7 +126,7 @@ class TestEngineSync:
         memory_engine._execute(f'DROP TABLE IF EXISTS "{doc_table_name}"')
 
     @pytest.mark.asyncio
-    async def test_cross_env_sync_engine(self, memory_engine: PostgresEngine):
+    async def test_cross_env_sync_engine(self, memory_engine: PostgresEngine) -> None:
         history = PostgresChatMessageHistory.create_sync(
             engine=memory_engine, session_id="test", table_name=table_name
         )
@@ -181,7 +183,7 @@ class TestEngineAsync:
         await engine._engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_cross_env_engine(self, async_engine: PostgresEngine):
+    async def test_cross_env_engine(self, async_engine: PostgresEngine) -> None:
         history = PostgresChatMessageHistory.create_sync(
             engine=async_engine, session_id="test", table_name=table_name_async
         )
@@ -259,7 +261,7 @@ class TestEngineAsync:
         history.clear()
 
     @pytest.mark.asyncio
-    async def test_chat_table_async(self, async_engine: PostgresEngine):
+    async def test_chat_table_async(self, async_engine: PostgresEngine) -> None:
         with pytest.raises(ValueError):
             await PostgresChatMessageHistory.create(
                 engine=async_engine,
@@ -268,7 +270,7 @@ class TestEngineAsync:
             )
 
     @pytest.mark.asyncio
-    async def test_chat_schema_async(self, async_engine: PostgresEngine):
+    async def test_chat_schema_async(self, async_engine: PostgresEngine) -> None:
         table_name = "test_table" + str(uuid.uuid4())
         await async_engine.ainit_document_table(table_name=table_name)
         with pytest.raises(IndexError):

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -178,6 +178,7 @@ class TestEngineAsync:
 
             engine = PostgresEngine.from_engine(engine)
             await engine._aexecute("SELECT 1")
+            assert len(engine._fetch("SELECT NOW();")) == 1
             await engine._engine.dispose()
 
     async def test_column(self, engine):
@@ -342,4 +343,4 @@ class TestEngineSync:
         assert engine
         engine._execute("SELECT 1")
         engine._connector.close()
-        engine._engine.dispose()
+        engine._run_as_sync(engine._engine.dispose())

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -78,10 +78,15 @@ class TestEngineAsync:
             database=db_name,
         )
         yield engine
+
+        await engine._connector.close_async()
         await engine._engine.dispose()
 
     async def test_execute(self, engine):
         await engine._aexecute("SELECT 1")
+
+    async def test_cross_env_execute(self, engine):
+        engine._execute("SELECT 1")
 
     async def test_init_table(self, engine):
         await engine.ainit_vectorstore_table(DEFAULT_TABLE, VECTOR_SIZE)
@@ -240,10 +245,14 @@ class TestEngineSync:
             database=db_name,
         )
         yield engine
-        engine._engine.dispose()
+        engine._run_as_sync(engine._connector.close_async())
+        engine._run_as_sync(engine._engine.dispose())
 
-    async def test_execute(self, engine):
+    def test_execute(self, engine):
         engine._execute("SELECT 1")
+
+    async def test_cross_env_execute(self, engine):
+        await engine._aexecute("SELECT 1")
 
     async def test_init_table(self, engine):
         engine.init_vectorstore_table(DEFAULT_TABLE, VECTOR_SIZE)

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -157,7 +157,7 @@ class TestEngineAsync:
         db_name,
         user,
         password,
-    ) -> None:
+    ):
         async def init_connection_pool(connector: Connector) -> AsyncEngine:
             async def getconn():
                 conn = await connector.connect_async(

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -178,6 +178,7 @@ class TestEngineAsync:
 
             engine = PostgresEngine.from_engine(engine)
             await engine._aexecute("SELECT 1")
+            await engine._engine.dispose()
 
     async def test_column(self, engine):
         with pytest.raises(ValueError):

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -180,9 +180,6 @@ class TestEngineAsync:
         pool = await init_connection_pool(connector)
         engine = PostgresEngine.from_engine(pool)
 
-        await engine._aexecute("SELECT 1;")
-        engine._execute("SELECT 1;")
-
         assert len(await engine._afetch("SELECT NOW();")) == 1
         assert len(engine._fetch("SELECT NOW();")) == 1
         await engine._engine.dispose()

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -15,13 +15,13 @@
 import os
 import uuid
 
-import asyncpg  # type: ignore
 import pytest
 import pytest_asyncio
 from google.cloud.sql.connector import Connector, create_async_connector
 from langchain_core.embeddings import DeterministicFakeEmbedding
 from sqlalchemy import VARCHAR
 from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine
 
@@ -173,6 +173,7 @@ class TestEngineAsync:
             pool = create_async_engine(
                 "postgresql+asyncpg://",
                 async_creator=getconn,
+                poolclass=NullPool,
             )
             return pool
 

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -148,38 +148,38 @@ class TestEngineAsync:
         await engine._aexecute("SELECT 1")
         PostgresEngine._connector = None
 
-    async def test_from_engine(
-        self,
-        db_project,
-        db_region,
-        db_instance,
-        db_name,
-        user,
-        password,
-    ):
-        async with Connector() as connector:
+    # async def test_from_engine(
+    #     self,
+    #     db_project,
+    #     db_region,
+    #     db_instance,
+    #     db_name,
+    #     user,
+    #     password,
+    # ):
+    #     async with Connector() as connector:
 
-            async def getconn() -> asyncpg.Connection:
-                conn = await connector.connect_async(  # type: ignore
-                    f"{db_project}:{db_region}:{db_instance}",
-                    "asyncpg",
-                    user=user,
-                    password=password,
-                    db=db_name,
-                    enable_iam_auth=False,
-                    ip_type=IPTypes.PUBLIC,
-                )
-                return conn
+    #         async def getconn() -> asyncpg.Connection:
+    #             conn = await connector.connect_async(  # type: ignore
+    #                 f"{db_project}:{db_region}:{db_instance}",
+    #                 "asyncpg",
+    #                 user=user,
+    #                 password=password,
+    #                 db=db_name,
+    #                 enable_iam_auth=False,
+    #                 ip_type=IPTypes.PUBLIC,
+    #             )
+    #             return conn
 
-            engine = create_async_engine(
-                "postgresql+asyncpg://",
-                async_creator=getconn,
-            )
+    #         engine = create_async_engine(
+    #             "postgresql+asyncpg://",
+    #             async_creator=getconn,
+    #         )
 
-            engine = PostgresEngine.from_engine(engine)
-            await engine._aexecute("SELECT 1")
-            assert len(engine._fetch("SELECT NOW();")) == 1
-            await engine._engine.dispose()
+    #         engine = PostgresEngine.from_engine(engine)
+    #         await engine._aexecute("SELECT 1")
+    #         assert len(engine._fetch("SELECT NOW();")) == 1
+    #         await engine._engine.dispose()
 
     async def test_column(self, engine):
         with pytest.raises(ValueError):

--- a/tests/test_postgresql_engine.py
+++ b/tests/test_postgresql_engine.py
@@ -156,9 +156,8 @@ class TestEngineAsync:
         db_name,
         user,
         password,
-    ):
+    ) -> None:
         async def init_connection_pool(connector: Connector):
-            # initialize Connector object for connections to Cloud SQL
             async def getconn():
                 conn = await connector.connect_async(
                     f"{db_project}:{db_region}:{db_instance}",
@@ -171,8 +170,6 @@ class TestEngineAsync:
                 )
                 return conn
 
-            # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-            # 'async_creator' argument to 'create_async_engine'
             pool = create_async_engine(
                 "postgresql+asyncpg://",
                 async_creator=getconn,
@@ -182,9 +179,11 @@ class TestEngineAsync:
         connector = await create_async_connector()
         pool = await init_connection_pool(connector)
         engine = PostgresEngine.from_engine(pool)
-        await engine._aexecute("SELECT 1")
-        r = await engine._afetch("SELECT NOW();")
-        assert len(r) == 1
+
+        await engine._aexecute("SELECT 1;")
+        engine._execute("SELECT 1;")
+
+        assert len(await engine._afetch("SELECT NOW();")) == 1
         assert len(engine._fetch("SELECT NOW();")) == 1
         await engine._engine.dispose()
 

--- a/tests/test_postgresql_loader.py
+++ b/tests/test_postgresql_loader.py
@@ -106,7 +106,6 @@ class TestLoaderAsync:
         loader = await PostgresLoader.create(
             engine=engine,
             query=f'SELECT * FROM "{table_name}";',
-            table_name=table_name,
         )
 
         documents = await self._collect_async_items(loader.alazy_load())

--- a/tests/test_postgresql_loader.py
+++ b/tests/test_postgresql_loader.py
@@ -84,55 +84,47 @@ class TestLoaderAsync:
             )
 
     async def test_load_from_query_default(self, engine):
-        try:
-            # await self._cleanup_table(engine)
-            query = f"""
-                    CREATE TABLE IF NOT EXISTS "{table_name}" (
-                        fruit_id SERIAL PRIMARY KEY,
-                        fruit_name VARCHAR(100) NOT NULL,
-                        variety VARCHAR(50),
-                        quantity_in_stock INT NOT NULL,
-                        price_per_unit INT NOT NULL,
-                        organic INT NOT NULL
-                    )
-                """
-            await engine._aexecute(query)
-
-            insert_query = f"""
-                INSERT INTO "{table_name}" (
-                    fruit_name, variety, quantity_in_stock, price_per_unit, organic
-                ) VALUES ('Apple', 'Granny Smith', 150, 1, 1);
-            """
-            await engine._aexecute(insert_query)
-
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                table_name=table_name,
-            )
-
-            documents = await self._collect_async_items(loader.alazy_load())
-
-            assert documents == [
-                Document(
-                    page_content="1",
-                    metadata={
-                        "fruit_name": "Apple",
-                        "variety": "Granny Smith",
-                        "quantity_in_stock": 150,
-                        "price_per_unit": 1,
-                        "organic": 1,
-                    },
+        query = f"""
+                CREATE TABLE IF NOT EXISTS "{table_name}" (
+                    fruit_id SERIAL PRIMARY KEY,
+                    fruit_name VARCHAR(100) NOT NULL,
+                    variety VARCHAR(50),
+                    quantity_in_stock INT NOT NULL,
+                    price_per_unit INT NOT NULL,
+                    organic INT NOT NULL
                 )
-            ]
-        except Exception as e:
-            print(e)
-        # finally:
-        # await self._cleanup_table(engine)
+            """
+        await engine._aexecute(query)
+
+        insert_query = f"""
+            INSERT INTO "{table_name}" (
+                fruit_name, variety, quantity_in_stock, price_per_unit, organic
+            ) VALUES ('Apple', 'Granny Smith', 150, 1, 1);
+        """
+        await engine._aexecute(insert_query)
+
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            table_name=table_name,
+        )
+
+        documents = await self._collect_async_items(loader.alazy_load())
+
+        assert documents == [
+            Document(
+                page_content="1",
+                metadata={
+                    "fruit_name": "Apple",
+                    "variety": "Granny Smith",
+                    "quantity_in_stock": 150,
+                    "price_per_unit": 1,
+                    "organic": 1,
+                },
+            )
+        ]
 
     async def test_load_from_query_customized_content_customized_metadata(self, engine):
-        # try:
-        # await self._cleanup_table(engine)
         query = f"""
                 CREATE TABLE IF NOT EXISTS "{table_name}" (
                     fruit_id SERIAL PRIMARY KEY,
@@ -184,12 +176,7 @@ class TestLoaderAsync:
             ),
         ]
 
-        # finally:
-        # await self._cleanup_table(engine)
-
     async def test_load_from_query_customized_content_default_metadata(self, engine):
-        # try:
-        # await self._cleanup_table(engine)
         query = f"""
                 CREATE TABLE IF NOT EXISTS "{table_name}" (
                     fruit_id SERIAL PRIMARY KEY,
@@ -218,7 +205,6 @@ class TestLoaderAsync:
             ],
         )
 
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         assert documents == [
@@ -243,7 +229,6 @@ class TestLoaderAsync:
             format="JSON",
         )
 
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         assert documents == [
@@ -257,12 +242,7 @@ class TestLoaderAsync:
             )
         ]
 
-        # finally:
-        # await self._cleanup_table(engine)
-
     async def test_load_from_query_default_content_customized_metadata(self, engine):
-        # try:
-        # await self._cleanup_table(engine)
         query = f"""
                 CREATE TABLE IF NOT EXISTS "{table_name}" (
                     fruit_id SERIAL PRIMARY KEY,
@@ -292,26 +272,14 @@ class TestLoaderAsync:
             metadata_columns=["fruit_name", "organic"],
         )
 
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = loader.lazy_load()
 
         assert next(documents) == Document(
             page_content="1",
             metadata={"fruit_name": "Apple", "organic": 1},
         )
-        # assert documents == [
-        #     Document(
-        #         page_content="1",
-        #         metadata={"fruit_name": "Apple", "organic": 1},
-        #     )
-        # ]
-
-        # finally:
-        # await self._cleanup_table(engine)
 
     async def test_load_from_query_with_langchain_metadata(self, engine):
-        # try:
-        # await self._cleanup_table(engine)
         query = f"""
             CREATE TABLE IF NOT EXISTS "{table_name}"(
                 fruit_id SERIAL PRIMARY KEY,
@@ -340,7 +308,6 @@ class TestLoaderAsync:
             ],
         )
 
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         assert documents == [
@@ -353,12 +320,7 @@ class TestLoaderAsync:
             )
         ]
 
-        # finally:
-        # await self._cleanup_table(engine)
-
     async def test_load_from_query_with_json(self, engine):
-        # try:
-        # await self._cleanup_table(engine)
         query = f"""
             CREATE TABLE IF NOT EXISTS "{table_name}"(
                 fruit_id SERIAL PRIMARY KEY,
@@ -387,7 +349,6 @@ class TestLoaderAsync:
             ],
         )
 
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         assert documents == [
@@ -400,14 +361,9 @@ class TestLoaderAsync:
             )
         ]
 
-        # finally:
-        # await self._cleanup_table(engine)
-
     async def test_load_from_query_customized_content_default_metadata_custom_formatter(
         self, engine
     ):
-        # try:
-        # await self._cleanup_table(engine)
         query = f"""
                 CREATE TABLE IF NOT EXISTS "{table_name}" (
                     fruit_id SERIAL PRIMARY KEY,
@@ -442,7 +398,6 @@ class TestLoaderAsync:
             formatter=my_formatter,
         )
 
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         assert documents == [
@@ -456,14 +411,9 @@ class TestLoaderAsync:
             )
         ]
 
-        # finally:
-        # await self._cleanup_table(engine)
-
     async def test_load_from_query_customized_content_default_metadata_custom_page_content_format(
         self, engine
     ):
-        # try:
-        # await self._cleanup_table(engine)
         query = f"""
                 CREATE TABLE IF NOT EXISTS "{table_name}" (
                     fruit_id SERIAL PRIMARY KEY,
@@ -493,7 +443,6 @@ class TestLoaderAsync:
             format="YAML",
         )
 
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         assert documents == [
@@ -506,9 +455,6 @@ class TestLoaderAsync:
                 },
             )
         ]
-
-        # finally:
-        # await self._cleanup_table(engine)
 
     async def test_save_doc_with_default_metadata(self, engine):
         # try:
@@ -532,7 +478,6 @@ class TestLoaderAsync:
         loader = await PostgresLoader.create(engine=engine, table_name=table_name)
 
         await saver.aadd_documents(test_docs)
-        # documents = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         assert documents == test_docs
@@ -540,12 +485,9 @@ class TestLoaderAsync:
             "page_content",
             "langchain_metadata",
         ]
-        # finally:
-        # await self._cleanup_table(engine)
 
     @pytest.mark.parametrize("store_metadata", [True, False])
     async def test_save_doc_with_customized_metadata(self, engine, store_metadata):
-        # await self._cleanup_table(engine)
         await engine.ainit_document_table(
             table_name,
             metadata_columns=[
@@ -575,7 +517,6 @@ class TestLoaderAsync:
         )
 
         await saver.aadd_documents(test_docs)
-        # docs = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
 
         if store_metadata:
@@ -600,8 +541,6 @@ class TestLoaderAsync:
             ]
 
     async def test_save_doc_without_metadata(self, engine):
-        # try:
-        # await self._cleanup_table(engine)
         await engine.ainit_document_table(table_name, store_metadata=False)
         test_docs = [
             Document(
@@ -622,11 +561,6 @@ class TestLoaderAsync:
         )
 
         docs = await self._collect_async_items(loader.alazy_load())
-        # results = []
-        # async for doc in loader.alazy_load():
-        #     results.append(doc)
-
-        # documents = await loader.aload()
 
         assert docs == [
             Document(
@@ -637,14 +571,9 @@ class TestLoaderAsync:
         assert (await engine._aload_table_schema(table_name)).columns.keys() == [
             "page_content",
         ]
-        # finally:
-        # await self._cleanup_table(engine)
 
     async def test_delete_doc_with_default_metadata(self, engine):
-        # await self._cleanup_table(engine)
         await engine.ainit_document_table(table_name)
-
-        # try:
         test_docs = [
             Document(
                 page_content="Apple Granny Smith 150 0.99 1",
@@ -659,24 +588,18 @@ class TestLoaderAsync:
         loader = await PostgresLoader.create(engine=engine, table_name=table_name)
 
         await saver.aadd_documents(test_docs)
-        # docs = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
         assert documents == test_docs
 
         await saver.adelete(documents[:1])
-        # assert len(await self._collect_async_items(loader.alazy_load())) == 1
         documents = await loader.aload()
         assert len(documents) == 1
 
         await saver.adelete(documents)
-        # assert len(await self._collect_async_items(loader.alazy_load())) == 0
         documents = await loader.aload()
         assert len(documents) == 0
-        # finally:
-        # await self._cleanup_table(engine)
 
     async def test_delete_doc_with_query(self, engine):
-        # await self._cleanup_table(engine)
         await engine.ainit_document_table(
             table_name,
             metadata_columns=[
@@ -692,7 +615,6 @@ class TestLoaderAsync:
             store_metadata=True,
         )
 
-        # try:
         test_docs = [
             Document(
                 page_content="Granny Smith 150 0.99",
@@ -724,22 +646,17 @@ class TestLoaderAsync:
         loader = await PostgresLoader.create(engine=engine, query=query)
 
         await saver.aadd_documents(test_docs)
-        # docs = await self._collect_async_items(loader.alazy_load())
         documents = await loader.aload()
         assert len(documents) == 1
 
         await saver.adelete(documents)
-        # assert len(await self._collect_async_items(loader.alazy_load())) == 0
         documents = await loader.aload()
         assert len(documents) == 0
-        # finally:
-        # await self._cleanup_table(engine)
 
     @pytest.mark.parametrize("metadata_json_column", [None, "metadata_col_test"])
     async def test_delete_doc_with_customized_metadata(
         self, engine, metadata_json_column
     ):
-        # await self._cleanup_table(engine)
         content_column = "content_col_test"
         await engine.ainit_document_table(
             table_name,
@@ -787,12 +704,10 @@ class TestLoaderAsync:
         assert len(docs) == 2
 
         await saver.adelete(docs[:1])
-        # assert len(await self._collect_async_items(loader.alazy_load())) == 1
         documents = await loader.aload()
         assert len(documents) == 1
 
         await saver.adelete(docs)
-        # assert len(await self._collect_async_items(loader.alazy_load())) == 0
         documents = await loader.aload()
         assert len(documents) == 0
 
@@ -825,7 +740,6 @@ class TestLoaderSync:
         assert engine
 
     async def test_load_from_query_default_sync(self, sync_engine):
-        # try:
         self._cleanup_table(sync_engine)
         sync_engine.init_document_table(table_name)
         saver = PostgresDocumentSaver.create_sync(
@@ -854,5 +768,4 @@ class TestLoaderSync:
         documents = loader.load()
         assert len(documents) == 0
 
-        # finally:
         self._cleanup_table(sync_engine)

--- a/tests/test_postgresql_loader.py
+++ b/tests/test_postgresql_loader.py
@@ -47,17 +47,6 @@ class TestLoaderAsync:
         )
         yield engine
 
-    @pytest_asyncio.fixture
-    def sync_engine(self):
-        PostgresEngine._connector = None
-        engine = PostgresEngine.from_instance(
-            project_id=project_id,
-            instance=instance_id,
-            region=region,
-            database=db_name,
-        )
-        yield engine
-
     async def _collect_async_items(self, docs_generator):
         """Collects items from an async generator."""
         docs = []
@@ -139,7 +128,9 @@ class TestLoaderAsync:
         finally:
             await self._cleanup_table(engine)
 
-    async def test_load_from_query_customized_content_customized_metadata(self, engine):
+    async def test_load_from_query_customized_content_customized_metadata(
+        self, engine
+    ):
         try:
             await self._cleanup_table(engine)
             query = f"""
@@ -195,7 +186,9 @@ class TestLoaderAsync:
         finally:
             await self._cleanup_table(engine)
 
-    async def test_load_from_query_customized_content_default_metadata(self, engine):
+    async def test_load_from_query_customized_content_default_metadata(
+        self, engine
+    ):
         try:
             await self._cleanup_table(engine)
             query = f"""
@@ -266,7 +259,9 @@ class TestLoaderAsync:
         finally:
             await self._cleanup_table(engine)
 
-    async def test_load_from_query_default_content_customized_metadata(self, engine):
+    async def test_load_from_query_default_content_customized_metadata(
+        self, engine
+    ):
         try:
             await self._cleanup_table(engine)
             query = f"""
@@ -427,7 +422,9 @@ class TestLoaderAsync:
 
             def my_formatter(row, content_columns):
                 return "-".join(
-                    str(row[column]) for column in content_columns if column in row
+                    str(row[column])
+                    for column in content_columns
+                    if column in row
                 )
 
             loader = await PostgresLoader.create(
@@ -528,13 +525,17 @@ class TestLoaderAsync:
             saver = await PostgresDocumentSaver.create(
                 engine=engine, table_name=table_name
             )
-            loader = await PostgresLoader.create(engine=engine, table_name=table_name)
+            loader = await PostgresLoader.create(
+                engine=engine, table_name=table_name
+            )
 
             await saver.aadd_documents(test_docs)
             docs = await self._collect_async_items(loader.alazy_load())
 
             assert docs == test_docs
-            assert (await engine._aload_table_schema(table_name)).columns.keys() == [
+            assert (
+                await engine._aload_table_schema(table_name)
+            ).columns.keys() == [
                 "page_content",
                 "langchain_metadata",
             ]
@@ -542,7 +543,9 @@ class TestLoaderAsync:
             await self._cleanup_table(engine)
 
     @pytest.mark.parametrize("store_metadata", [True, False])
-    async def test_save_doc_with_customized_metadata(self, engine, store_metadata):
+    async def test_save_doc_with_customized_metadata(
+        self, engine, store_metadata
+    ):
         await self._cleanup_table(engine)
         await engine.ainit_document_table(
             table_name,
@@ -562,7 +565,9 @@ class TestLoaderAsync:
                 },
             ),
         ]
-        saver = await PostgresDocumentSaver.create(engine=engine, table_name=table_name)
+        saver = await PostgresDocumentSaver.create(
+            engine=engine, table_name=table_name
+        )
         loader = await PostgresLoader.create(
             engine=engine,
             table_name=table_name,
@@ -577,7 +582,9 @@ class TestLoaderAsync:
 
         if store_metadata:
             docs == test_docs
-            assert (await engine._aload_table_schema(table_name)).columns.keys() == [
+            assert (
+                await engine._aload_table_schema(table_name)
+            ).columns.keys() == [
                 "page_content",
                 "fruit_name",
                 "organic",
@@ -590,7 +597,9 @@ class TestLoaderAsync:
                     metadata={"fruit_name": "Apple", "organic": True},
                 ),
             ]
-            assert (await engine._aload_table_schema(table_name)).columns.keys() == [
+            assert (
+                await engine._aload_table_schema(table_name)
+            ).columns.keys() == [
                 "page_content",
                 "fruit_name",
                 "organic",
@@ -628,7 +637,9 @@ class TestLoaderAsync:
                     metadata={},
                 ),
             ]
-            assert (await engine._aload_table_schema(table_name)).columns.keys() == [
+            assert (
+                await engine._aload_table_schema(table_name)
+            ).columns.keys() == [
                 "page_content",
             ]
         finally:
@@ -652,17 +663,23 @@ class TestLoaderAsync:
             saver = await PostgresDocumentSaver.create(
                 engine=engine, table_name=table_name
             )
-            loader = await PostgresLoader.create(engine=engine, table_name=table_name)
+            loader = await PostgresLoader.create(
+                engine=engine, table_name=table_name
+            )
 
             await saver.aadd_documents(test_docs)
             docs = await self._collect_async_items(loader.alazy_load())
             assert docs == test_docs
 
             await saver.adelete(docs[:1])
-            assert len(await self._collect_async_items(loader.alazy_load())) == 1
+            assert (
+                len(await self._collect_async_items(loader.alazy_load())) == 1
+            )
 
             await saver.adelete(docs)
-            assert len(await self._collect_async_items(loader.alazy_load())) == 0
+            assert (
+                len(await self._collect_async_items(loader.alazy_load())) == 0
+            )
         finally:
             await self._cleanup_table(engine)
 
@@ -721,11 +738,15 @@ class TestLoaderAsync:
             assert len(docs) == 1
 
             await saver.adelete(docs)
-            assert len(await self._collect_async_items(loader.alazy_load())) == 0
+            assert (
+                len(await self._collect_async_items(loader.alazy_load())) == 0
+            )
         finally:
             await self._cleanup_table(engine)
 
-    @pytest.mark.parametrize("metadata_json_column", [None, "metadata_col_test"])
+    @pytest.mark.parametrize(
+        "metadata_json_column", [None, "metadata_col_test"]
+    )
     async def test_delete_doc_with_customized_metadata(
         self, engine, metadata_json_column
     ):
@@ -782,6 +803,25 @@ class TestLoaderAsync:
         await saver.adelete(docs)
         assert len(await self._collect_async_items(loader.alazy_load())) == 0
 
+
+@pytest.mark.asyncio
+class TestLoaderSync:
+
+    def _cleanup_table(self, engine):
+        query = f'DROP TABLE IF EXISTS "{table_name}"'
+        engine._execute(query)
+
+    @pytest_asyncio.fixture
+    def sync_engine(self):
+        PostgresEngine._connector = None
+        engine = PostgresEngine.from_instance(
+            project_id=project_id,
+            instance=instance_id,
+            region=region,
+            database=db_name,
+        )
+        yield engine
+
     def test_sync_engine(self):
         PostgresEngine._connector = None
         engine = PostgresEngine.from_instance(
@@ -794,7 +834,7 @@ class TestLoaderAsync:
 
     async def test_load_from_query_default_sync(self, sync_engine):
         try:
-            sync_engine._run_as_sync(self._cleanup_table(sync_engine))
+            self._cleanup_table(sync_engine)
             sync_engine.init_document_table(table_name)
             saver = PostgresDocumentSaver.create_sync(
                 engine=sync_engine, table_name=table_name
@@ -823,4 +863,4 @@ class TestLoaderAsync:
             assert len(documents) == 0
 
         finally:
-            sync_engine._run_as_sync(self._cleanup_table(sync_engine))
+            self._cleanup_table(sync_engine)

--- a/tests/test_postgresql_loader.py
+++ b/tests/test_postgresql_loader.py
@@ -47,6 +47,8 @@ class TestLoaderAsync:
         )
         yield engine
 
+        await self._cleanup_table(engine)
+
     async def _collect_async_items(self, docs_generator):
         """Collects items from an async generator."""
         docs = []
@@ -83,7 +85,7 @@ class TestLoaderAsync:
 
     async def test_load_from_query_default(self, engine):
         try:
-            await self._cleanup_table(engine)
+            # await self._cleanup_table(engine)
             query = f"""
                     CREATE TABLE IF NOT EXISTS "{table_name}" (
                         fruit_id SERIAL PRIMARY KEY,
@@ -125,428 +127,426 @@ class TestLoaderAsync:
             ]
         except Exception as e:
             print(e)
-        finally:
-            await self._cleanup_table(engine)
+        # finally:
+        # await self._cleanup_table(engine)
 
     async def test_load_from_query_customized_content_customized_metadata(
         self, engine
     ):
-        try:
-            await self._cleanup_table(engine)
-            query = f"""
-                    CREATE TABLE IF NOT EXISTS "{table_name}" (
-                        fruit_id SERIAL PRIMARY KEY,
-                        fruit_name VARCHAR(100) NOT NULL,
-                        variety VARCHAR(50),
-                        quantity_in_stock INT NOT NULL,
-                        price_per_unit INT NOT NULL,
-                        organic INT NOT NULL
-                    )
-                """
-            await engine._aexecute(query)
-
-            insert_query = f"""
-                INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
-                VALUES ('Apple', 'Granny Smith', 150, 0.99, 1),
-                       ('Banana', 'Cavendish', 200, 0.59, 0),
-                       ('Orange', 'Navel', 80, 1.29, 1);
-            """
-            await engine._aexecute(insert_query)
-
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                content_columns=[
-                    "fruit_name",
-                    "variety",
-                    "quantity_in_stock",
-                    "price_per_unit",
-                    "organic",
-                ],
-                metadata_columns=["fruit_id"],
-            )
-
-            documents = await self._collect_async_items(loader.alazy_load())
-
-            assert documents == [
-                Document(
-                    page_content="Apple Granny Smith 150 1 1",
-                    metadata={"fruit_id": 1},
-                ),
-                Document(
-                    page_content="Banana Cavendish 200 1 0",
-                    metadata={"fruit_id": 2},
-                ),
-                Document(
-                    page_content="Orange Navel 80 1 1",
-                    metadata={"fruit_id": 3},
-                ),
-            ]
-
-        finally:
-            await self._cleanup_table(engine)
-
-    async def test_load_from_query_customized_content_default_metadata(
-        self, engine
-    ):
-        try:
-            await self._cleanup_table(engine)
-            query = f"""
-                    CREATE TABLE IF NOT EXISTS "{table_name}" (
-                        fruit_id SERIAL PRIMARY KEY,
-                        fruit_name VARCHAR(100) NOT NULL,
-                        variety VARCHAR(50),
-                        quantity_in_stock INT NOT NULL,
-                        price_per_unit INT NOT NULL,
-                        organic INT NOT NULL
-                    )
-                """
-            await engine._aexecute(query)
-
-            insert_query = f"""
-                INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
-                VALUES ('Apple', 'Granny Smith', 150, 1, 1);
-            """
-            await engine._aexecute(insert_query)
-
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                content_columns=[
-                    "variety",
-                    "quantity_in_stock",
-                    "price_per_unit",
-                ],
-            )
-
-            documents = await self._collect_async_items(loader.alazy_load())
-
-            assert documents == [
-                Document(
-                    page_content="Granny Smith 150 1",
-                    metadata={
-                        "fruit_id": 1,
-                        "fruit_name": "Apple",
-                        "organic": 1,
-                    },
-                )
-            ]
-
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                content_columns=[
-                    "variety",
-                    "quantity_in_stock",
-                    "price_per_unit",
-                ],
-                format="JSON",
-            )
-
-            documents = await self._collect_async_items(loader.alazy_load())
-
-            assert documents == [
-                Document(
-                    page_content='{"variety": "Granny Smith", "quantity_in_stock": 150, "price_per_unit": 1}',
-                    metadata={
-                        "fruit_id": 1,
-                        "fruit_name": "Apple",
-                        "organic": 1,
-                    },
-                )
-            ]
-
-        finally:
-            await self._cleanup_table(engine)
-
-    async def test_load_from_query_default_content_customized_metadata(
-        self, engine
-    ):
-        try:
-            await self._cleanup_table(engine)
-            query = f"""
-                    CREATE TABLE IF NOT EXISTS "{table_name}" (
-                        fruit_id SERIAL PRIMARY KEY,
-                        fruit_name VARCHAR(100) NOT NULL,
-                        variety VARCHAR(50),
-                        quantity_in_stock INT NOT NULL,
-                        price_per_unit INT NOT NULL,
-                        organic INT NOT NULL
-                    )
-                """
-            await engine._aexecute(query)
-
-            insert_query = f"""
-                        INSERT INTO "{table_name}" (
-                            fruit_name,
-                            variety,
-                            quantity_in_stock,
-                            price_per_unit,
-                            organic
-                        ) VALUES ('Apple', 'Granny Smith', 150, 1, 1);
-            """
-            await engine._aexecute(insert_query)
-
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                metadata_columns=["fruit_name", "organic"],
-            )
-
-            documents = await self._collect_async_items(loader.alazy_load())
-
-            assert documents == [
-                Document(
-                    page_content="1",
-                    metadata={"fruit_name": "Apple", "organic": 1},
-                )
-            ]
-
-        finally:
-            await self._cleanup_table(engine)
-
-    async def test_load_from_query_with_langchain_metadata(self, engine):
-        try:
-            await self._cleanup_table(engine)
-            query = f"""
-                CREATE TABLE IF NOT EXISTS "{table_name}"(
+        # try:
+        # await self._cleanup_table(engine)
+        query = f"""
+                CREATE TABLE IF NOT EXISTS "{table_name}" (
                     fruit_id SERIAL PRIMARY KEY,
                     fruit_name VARCHAR(100) NOT NULL,
                     variety VARCHAR(50),
                     quantity_in_stock INT NOT NULL,
                     price_per_unit INT NOT NULL,
-                    langchain_metadata JSON NOT NULL
+                    organic INT NOT NULL
                 )
-                """
-            await engine._aexecute(query)
+            """
+        await engine._aexecute(query)
 
-            metadata = json.dumps({"organic": 1})
-            insert_query = f"""
-                INSERT INTO "{table_name}"
-                (fruit_name, variety, quantity_in_stock, price_per_unit, langchain_metadata)
-                VALUES ('Apple', 'Granny Smith', 150, 1, '{metadata}');"""
-            await engine._aexecute(insert_query)
+        insert_query = f"""
+            INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
+            VALUES ('Apple', 'Granny Smith', 150, 0.99, 1),
+                    ('Banana', 'Cavendish', 200, 0.59, 0),
+                    ('Orange', 'Navel', 80, 1.29, 1);
+        """
+        await engine._aexecute(insert_query)
 
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                metadata_columns=[
-                    "fruit_name",
-                    "langchain_metadata",
-                ],
-            )
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            content_columns=[
+                "fruit_name",
+                "variety",
+                "quantity_in_stock",
+                "price_per_unit",
+                "organic",
+            ],
+            metadata_columns=["fruit_id"],
+        )
 
-            documents = await self._collect_async_items(loader.alazy_load())
+        documents = await self._collect_async_items(loader.alazy_load())
 
-            assert documents == [
-                Document(
-                    page_content="1",
-                    metadata={
-                        "fruit_name": "Apple",
-                        "organic": 1,
-                    },
-                )
-            ]
+        assert documents == [
+            Document(
+                page_content="Apple Granny Smith 150 1 1",
+                metadata={"fruit_id": 1},
+            ),
+            Document(
+                page_content="Banana Cavendish 200 1 0",
+                metadata={"fruit_id": 2},
+            ),
+            Document(
+                page_content="Orange Navel 80 1 1",
+                metadata={"fruit_id": 3},
+            ),
+        ]
 
-        finally:
-            await self._cleanup_table(engine)
+        # finally:
+        # await self._cleanup_table(engine)
 
-    async def test_load_from_query_with_json(self, engine):
-        try:
-            await self._cleanup_table(engine)
-            query = f"""
-                CREATE TABLE IF NOT EXISTS "{table_name}"(
+    async def test_load_from_query_customized_content_default_metadata(
+        self, engine
+    ):
+        # try:
+        # await self._cleanup_table(engine)
+        query = f"""
+                CREATE TABLE IF NOT EXISTS "{table_name}" (
                     fruit_id SERIAL PRIMARY KEY,
                     fruit_name VARCHAR(100) NOT NULL,
-                    variety JSON NOT NULL,
+                    variety VARCHAR(50),
                     quantity_in_stock INT NOT NULL,
                     price_per_unit INT NOT NULL,
-                    langchain_metadata JSON NOT NULL
+                    organic INT NOT NULL
                 )
-                """
-            await engine._aexecute(query)
+            """
+        await engine._aexecute(query)
 
-            metadata = json.dumps({"organic": 1})
-            variety = json.dumps({"type": "Granny Smith"})
-            insert_query = f"""
-                INSERT INTO "{table_name}"
-                (fruit_name, variety, quantity_in_stock, price_per_unit, langchain_metadata)
-                VALUES ('Apple', '{variety}', 150, 1, '{metadata}');"""
-            await engine._aexecute(insert_query)
+        insert_query = f"""
+            INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
+            VALUES ('Apple', 'Granny Smith', 150, 1, 1);
+        """
+        await engine._aexecute(insert_query)
 
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                metadata_columns=[
-                    "variety",
-                ],
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            content_columns=[
+                "variety",
+                "quantity_in_stock",
+                "price_per_unit",
+            ],
+        )
+
+        documents = await self._collect_async_items(loader.alazy_load())
+
+        assert documents == [
+            Document(
+                page_content="Granny Smith 150 1",
+                metadata={
+                    "fruit_id": 1,
+                    "fruit_name": "Apple",
+                    "organic": 1,
+                },
             )
+        ]
 
-            documents = await self._collect_async_items(loader.alazy_load())
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            content_columns=[
+                "variety",
+                "quantity_in_stock",
+                "price_per_unit",
+            ],
+            format="JSON",
+        )
 
-            assert documents == [
-                Document(
-                    page_content="1",
-                    metadata={
-                        "variety": {"type": "Granny Smith"},
-                        "organic": 1,
-                    },
+        documents = await self._collect_async_items(loader.alazy_load())
+
+        assert documents == [
+            Document(
+                page_content='{"variety": "Granny Smith", "quantity_in_stock": 150, "price_per_unit": 1}',
+                metadata={
+                    "fruit_id": 1,
+                    "fruit_name": "Apple",
+                    "organic": 1,
+                },
+            )
+        ]
+
+        # finally:
+        # await self._cleanup_table(engine)
+
+    async def test_load_from_query_default_content_customized_metadata(
+        self, engine
+    ):
+        # try:
+        # await self._cleanup_table(engine)
+        query = f"""
+                CREATE TABLE IF NOT EXISTS "{table_name}" (
+                    fruit_id SERIAL PRIMARY KEY,
+                    fruit_name VARCHAR(100) NOT NULL,
+                    variety VARCHAR(50),
+                    quantity_in_stock INT NOT NULL,
+                    price_per_unit INT NOT NULL,
+                    organic INT NOT NULL
                 )
-            ]
+            """
+        await engine._aexecute(query)
 
-        finally:
-            await self._cleanup_table(engine)
+        insert_query = f"""
+                    INSERT INTO "{table_name}" (
+                        fruit_name,
+                        variety,
+                        quantity_in_stock,
+                        price_per_unit,
+                        organic
+                    ) VALUES ('Apple', 'Granny Smith', 150, 1, 1);
+        """
+        await engine._aexecute(insert_query)
+
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            metadata_columns=["fruit_name", "organic"],
+        )
+
+        documents = await self._collect_async_items(loader.alazy_load())
+
+        assert documents == [
+            Document(
+                page_content="1",
+                metadata={"fruit_name": "Apple", "organic": 1},
+            )
+        ]
+
+        # finally:
+        # await self._cleanup_table(engine)
+
+    async def test_load_from_query_with_langchain_metadata(self, engine):
+        # try:
+        # await self._cleanup_table(engine)
+        query = f"""
+            CREATE TABLE IF NOT EXISTS "{table_name}"(
+                fruit_id SERIAL PRIMARY KEY,
+                fruit_name VARCHAR(100) NOT NULL,
+                variety VARCHAR(50),
+                quantity_in_stock INT NOT NULL,
+                price_per_unit INT NOT NULL,
+                langchain_metadata JSON NOT NULL
+            )
+            """
+        await engine._aexecute(query)
+
+        metadata = json.dumps({"organic": 1})
+        insert_query = f"""
+            INSERT INTO "{table_name}"
+            (fruit_name, variety, quantity_in_stock, price_per_unit, langchain_metadata)
+            VALUES ('Apple', 'Granny Smith', 150, 1, '{metadata}');"""
+        await engine._aexecute(insert_query)
+
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            metadata_columns=[
+                "fruit_name",
+                "langchain_metadata",
+            ],
+        )
+
+        documents = await self._collect_async_items(loader.alazy_load())
+
+        assert documents == [
+            Document(
+                page_content="1",
+                metadata={
+                    "fruit_name": "Apple",
+                    "organic": 1,
+                },
+            )
+        ]
+
+        # finally:
+        # await self._cleanup_table(engine)
+
+    async def test_load_from_query_with_json(self, engine):
+        # try:
+        # await self._cleanup_table(engine)
+        query = f"""
+            CREATE TABLE IF NOT EXISTS "{table_name}"(
+                fruit_id SERIAL PRIMARY KEY,
+                fruit_name VARCHAR(100) NOT NULL,
+                variety JSON NOT NULL,
+                quantity_in_stock INT NOT NULL,
+                price_per_unit INT NOT NULL,
+                langchain_metadata JSON NOT NULL
+            )
+            """
+        await engine._aexecute(query)
+
+        metadata = json.dumps({"organic": 1})
+        variety = json.dumps({"type": "Granny Smith"})
+        insert_query = f"""
+            INSERT INTO "{table_name}"
+            (fruit_name, variety, quantity_in_stock, price_per_unit, langchain_metadata)
+            VALUES ('Apple', '{variety}', 150, 1, '{metadata}');"""
+        await engine._aexecute(insert_query)
+
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            metadata_columns=[
+                "variety",
+            ],
+        )
+
+        documents = await self._collect_async_items(loader.alazy_load())
+
+        assert documents == [
+            Document(
+                page_content="1",
+                metadata={
+                    "variety": {"type": "Granny Smith"},
+                    "organic": 1,
+                },
+            )
+        ]
+
+        # finally:
+        # await self._cleanup_table(engine)
 
     async def test_load_from_query_customized_content_default_metadata_custom_formatter(
         self, engine
     ):
-        try:
-            await self._cleanup_table(engine)
-            query = f"""
-                    CREATE TABLE IF NOT EXISTS "{table_name}" (
-                        fruit_id SERIAL PRIMARY KEY,
-                        fruit_name VARCHAR(100) NOT NULL,
-                        variety VARCHAR(50),
-                        quantity_in_stock INT NOT NULL,
-                        price_per_unit INT NOT NULL,
-                        organic INT NOT NULL
-                    )
-                """
-            await engine._aexecute(query)
-
-            insert_query = f"""
-                        INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
-                        VALUES ('Apple', 'Granny Smith', 150, 1, 1);
-                        """
-            await engine._aexecute(insert_query)
-
-            def my_formatter(row, content_columns):
-                return "-".join(
-                    str(row[column])
-                    for column in content_columns
-                    if column in row
+        # try:
+        # await self._cleanup_table(engine)
+        query = f"""
+                CREATE TABLE IF NOT EXISTS "{table_name}" (
+                    fruit_id SERIAL PRIMARY KEY,
+                    fruit_name VARCHAR(100) NOT NULL,
+                    variety VARCHAR(50),
+                    quantity_in_stock INT NOT NULL,
+                    price_per_unit INT NOT NULL,
+                    organic INT NOT NULL
                 )
+            """
+        await engine._aexecute(query)
 
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                content_columns=[
-                    "variety",
-                    "quantity_in_stock",
-                    "price_per_unit",
-                ],
-                formatter=my_formatter,
+        insert_query = f"""
+                    INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
+                    VALUES ('Apple', 'Granny Smith', 150, 1, 1);
+                    """
+        await engine._aexecute(insert_query)
+
+        def my_formatter(row, content_columns):
+            return "-".join(
+                str(row[column]) for column in content_columns if column in row
             )
 
-            documents = await self._collect_async_items(loader.alazy_load())
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            content_columns=[
+                "variety",
+                "quantity_in_stock",
+                "price_per_unit",
+            ],
+            formatter=my_formatter,
+        )
 
-            assert documents == [
-                Document(
-                    page_content="Granny Smith-150-1",
-                    metadata={
-                        "fruit_id": 1,
-                        "fruit_name": "Apple",
-                        "organic": 1,
-                    },
-                )
-            ]
+        documents = await self._collect_async_items(loader.alazy_load())
 
-        finally:
-            await self._cleanup_table(engine)
+        assert documents == [
+            Document(
+                page_content="Granny Smith-150-1",
+                metadata={
+                    "fruit_id": 1,
+                    "fruit_name": "Apple",
+                    "organic": 1,
+                },
+            )
+        ]
+
+        # finally:
+        # await self._cleanup_table(engine)
 
     async def test_load_from_query_customized_content_default_metadata_custom_page_content_format(
         self, engine
     ):
-        try:
-            await self._cleanup_table(engine)
-            query = f"""
-                    CREATE TABLE IF NOT EXISTS "{table_name}" (
-                        fruit_id SERIAL PRIMARY KEY,
-                        fruit_name VARCHAR(100) NOT NULL,
-                        variety VARCHAR(50),
-                        quantity_in_stock INT NOT NULL,
-                        price_per_unit INT NOT NULL,
-                        organic INT NOT NULL
-                    )
-                """
-            await engine._aexecute(query)
-
-            insert_query = f"""
-                            INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
-                            VALUES ('Apple', 'Granny Smith', 150, 1, 1);
-                        """
-            await engine._aexecute(insert_query)
-
-            loader = await PostgresLoader.create(
-                engine=engine,
-                query=f'SELECT * FROM "{table_name}";',
-                content_columns=[
-                    "variety",
-                    "quantity_in_stock",
-                    "price_per_unit",
-                ],
-                format="YAML",
-            )
-
-            documents = await self._collect_async_items(loader.alazy_load())
-
-            assert documents == [
-                Document(
-                    page_content="variety: Granny Smith\nquantity_in_stock: 150\nprice_per_unit: 1",
-                    metadata={
-                        "fruit_id": 1,
-                        "fruit_name": "Apple",
-                        "organic": 1,
-                    },
+        # try:
+        # await self._cleanup_table(engine)
+        query = f"""
+                CREATE TABLE IF NOT EXISTS "{table_name}" (
+                    fruit_id SERIAL PRIMARY KEY,
+                    fruit_name VARCHAR(100) NOT NULL,
+                    variety VARCHAR(50),
+                    quantity_in_stock INT NOT NULL,
+                    price_per_unit INT NOT NULL,
+                    organic INT NOT NULL
                 )
-            ]
+            """
+        await engine._aexecute(query)
 
-        finally:
-            await self._cleanup_table(engine)
+        insert_query = f"""
+                        INSERT INTO "{table_name}" (fruit_name, variety, quantity_in_stock, price_per_unit, organic)
+                        VALUES ('Apple', 'Granny Smith', 150, 1, 1);
+                    """
+        await engine._aexecute(insert_query)
+
+        loader = await PostgresLoader.create(
+            engine=engine,
+            query=f'SELECT * FROM "{table_name}";',
+            content_columns=[
+                "variety",
+                "quantity_in_stock",
+                "price_per_unit",
+            ],
+            format="YAML",
+        )
+
+        documents = await self._collect_async_items(loader.alazy_load())
+
+        assert documents == [
+            Document(
+                page_content="variety: Granny Smith\nquantity_in_stock: 150\nprice_per_unit: 1",
+                metadata={
+                    "fruit_id": 1,
+                    "fruit_name": "Apple",
+                    "organic": 1,
+                },
+            )
+        ]
+
+        # finally:
+        # await self._cleanup_table(engine)
 
     async def test_save_doc_with_default_metadata(self, engine):
-        try:
-            await self._cleanup_table(engine)
-            await engine.ainit_document_table(table_name)
-            test_docs = [
-                Document(
-                    page_content="Apple Granny Smith 150 0.99 1",
-                    metadata={"fruit_id": 1},
-                ),
-                Document(
-                    page_content="Banana Cavendish 200 0.59 0",
-                    metadata={"fruit_id": 2},
-                ),
-                Document(
-                    page_content="Orange Navel 80 1.29 1",
-                    metadata={"fruit_id": 3},
-                ),
-            ]
-            saver = await PostgresDocumentSaver.create(
-                engine=engine, table_name=table_name
-            )
-            loader = await PostgresLoader.create(
-                engine=engine, table_name=table_name
-            )
+        # try:
+        # await self._cleanup_table(engine)
+        await engine.ainit_document_table(table_name)
+        test_docs = [
+            Document(
+                page_content="Apple Granny Smith 150 0.99 1",
+                metadata={"fruit_id": 1},
+            ),
+            Document(
+                page_content="Banana Cavendish 200 0.59 0",
+                metadata={"fruit_id": 2},
+            ),
+            Document(
+                page_content="Orange Navel 80 1.29 1",
+                metadata={"fruit_id": 3},
+            ),
+        ]
+        saver = await PostgresDocumentSaver.create(
+            engine=engine, table_name=table_name
+        )
+        loader = await PostgresLoader.create(
+            engine=engine, table_name=table_name
+        )
 
-            await saver.aadd_documents(test_docs)
-            docs = await self._collect_async_items(loader.alazy_load())
+        await saver.aadd_documents(test_docs)
+        docs = await self._collect_async_items(loader.alazy_load())
 
-            assert docs == test_docs
-            assert (
-                await engine._aload_table_schema(table_name)
-            ).columns.keys() == [
-                "page_content",
-                "langchain_metadata",
-            ]
-        finally:
-            await self._cleanup_table(engine)
+        assert docs == test_docs
+        assert (
+            await engine._aload_table_schema(table_name)
+        ).columns.keys() == [
+            "page_content",
+            "langchain_metadata",
+        ]
+        # finally:
+        # await self._cleanup_table(engine)
 
     @pytest.mark.parametrize("store_metadata", [True, False])
     async def test_save_doc_with_customized_metadata(
         self, engine, store_metadata
     ):
-        await self._cleanup_table(engine)
+        # await self._cleanup_table(engine)
         await engine.ainit_document_table(
             table_name,
             metadata_columns=[
@@ -606,85 +606,81 @@ class TestLoaderAsync:
             ]
 
     async def test_save_doc_without_metadata(self, engine):
-        try:
-            await self._cleanup_table(engine)
-            await engine.ainit_document_table(table_name, store_metadata=False)
-            test_docs = [
-                Document(
-                    page_content="Granny Smith 150 0.99",
-                    metadata={
-                        "fruit_id": 1,
-                        "fruit_name": "Apple",
-                        "organic": 1,
-                    },
-                ),
-            ]
-            saver = await PostgresDocumentSaver.create(
-                engine=engine, table_name=table_name
-            )
-            await saver.aadd_documents(test_docs)
+        # try:
+        # await self._cleanup_table(engine)
+        await engine.ainit_document_table(table_name, store_metadata=False)
+        test_docs = [
+            Document(
+                page_content="Granny Smith 150 0.99",
+                metadata={
+                    "fruit_id": 1,
+                    "fruit_name": "Apple",
+                    "organic": 1,
+                },
+            ),
+        ]
+        saver = await PostgresDocumentSaver.create(
+            engine=engine, table_name=table_name
+        )
+        await saver.aadd_documents(test_docs)
 
-            loader = await PostgresLoader.create(
-                engine=engine,
-                table_name=table_name,
-            )
+        loader = await PostgresLoader.create(
+            engine=engine,
+            table_name=table_name,
+        )
 
-            docs = await self._collect_async_items(loader.alazy_load())
+        docs = await self._collect_async_items(loader.alazy_load())
 
-            assert docs == [
-                Document(
-                    page_content="Granny Smith 150 0.99",
-                    metadata={},
-                ),
-            ]
-            assert (
-                await engine._aload_table_schema(table_name)
-            ).columns.keys() == [
-                "page_content",
-            ]
-        finally:
-            await self._cleanup_table(engine)
+        assert docs == [
+            Document(
+                page_content="Granny Smith 150 0.99",
+                metadata={},
+            ),
+        ]
+        assert (
+            await engine._aload_table_schema(table_name)
+        ).columns.keys() == [
+            "page_content",
+        ]
+        # finally:
+        # await self._cleanup_table(engine)
 
     async def test_delete_doc_with_default_metadata(self, engine):
-        await self._cleanup_table(engine)
+        # await self._cleanup_table(engine)
         await engine.ainit_document_table(table_name)
 
-        try:
-            test_docs = [
-                Document(
-                    page_content="Apple Granny Smith 150 0.99 1",
-                    metadata={"fruit_id": 1},
-                ),
-                Document(
-                    page_content="Banana Cavendish 200 0.59 0 1",
-                    metadata={"fruit_id": 2},
-                ),
-            ]
-            saver = await PostgresDocumentSaver.create(
-                engine=engine, table_name=table_name
-            )
-            loader = await PostgresLoader.create(
-                engine=engine, table_name=table_name
-            )
+        # try:
+        test_docs = [
+            Document(
+                page_content="Apple Granny Smith 150 0.99 1",
+                metadata={"fruit_id": 1},
+            ),
+            Document(
+                page_content="Banana Cavendish 200 0.59 0 1",
+                metadata={"fruit_id": 2},
+            ),
+        ]
+        saver = await PostgresDocumentSaver.create(
+            engine=engine, table_name=table_name
+        )
+        loader = await PostgresLoader.create(
+            engine=engine, table_name=table_name
+        )
 
-            await saver.aadd_documents(test_docs)
-            docs = await self._collect_async_items(loader.alazy_load())
-            assert docs == test_docs
+        await saver.aadd_documents(test_docs)
+        docs = await self._collect_async_items(loader.alazy_load())
+        assert docs == test_docs
 
-            await saver.adelete(docs[:1])
-            assert (
-                len(await self._collect_async_items(loader.alazy_load())) == 1
-            )
+        await saver.adelete(docs[:1])
+        assert len(await self._collect_async_items(loader.alazy_load())) == 1
 
-            await saver.adelete(docs)
-            assert (
-                len(await self._collect_async_items(loader.alazy_load())) == 0
-            )
-        finally:
-            await self._cleanup_table(engine)
+        await saver.adelete(docs)
+        assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        # finally:
+        # await self._cleanup_table(engine)
 
     async def test_delete_doc_with_query(self, engine):
-        await self._cleanup_table(engine)
+        # await self._cleanup_table(engine)
         await engine.ainit_document_table(
             table_name,
             metadata_columns=[
@@ -700,49 +696,47 @@ class TestLoaderAsync:
             store_metadata=True,
         )
 
-        try:
-            test_docs = [
-                Document(
-                    page_content="Granny Smith 150 0.99",
-                    metadata={
-                        "fruit-id": 1,
-                        "fruit_name": "Apple",
-                        "organic": True,
-                    },
-                ),
-                Document(
-                    page_content="Cavendish 200 0.59 0",
-                    metadata={
-                        "fruit_id": 2,
-                        "fruit_name": "Banana",
-                        "organic": False,
-                    },
-                ),
-                Document(
-                    page_content="Navel 80 1.29 1",
-                    metadata={
-                        "fruit_id": 3,
-                        "fruit_name": "Orange",
-                        "organic": True,
-                    },
-                ),
-            ]
-            saver = await PostgresDocumentSaver.create(
-                engine=engine, table_name=table_name
-            )
-            query = f"SELECT * FROM \"{table_name}\" WHERE fruit_name='Apple';"
-            loader = await PostgresLoader.create(engine=engine, query=query)
+        # try:
+        test_docs = [
+            Document(
+                page_content="Granny Smith 150 0.99",
+                metadata={
+                    "fruit-id": 1,
+                    "fruit_name": "Apple",
+                    "organic": True,
+                },
+            ),
+            Document(
+                page_content="Cavendish 200 0.59 0",
+                metadata={
+                    "fruit_id": 2,
+                    "fruit_name": "Banana",
+                    "organic": False,
+                },
+            ),
+            Document(
+                page_content="Navel 80 1.29 1",
+                metadata={
+                    "fruit_id": 3,
+                    "fruit_name": "Orange",
+                    "organic": True,
+                },
+            ),
+        ]
+        saver = await PostgresDocumentSaver.create(
+            engine=engine, table_name=table_name
+        )
+        query = f"SELECT * FROM \"{table_name}\" WHERE fruit_name='Apple';"
+        loader = await PostgresLoader.create(engine=engine, query=query)
 
-            await saver.aadd_documents(test_docs)
-            docs = await self._collect_async_items(loader.alazy_load())
-            assert len(docs) == 1
+        await saver.aadd_documents(test_docs)
+        docs = await self._collect_async_items(loader.alazy_load())
+        assert len(docs) == 1
 
-            await saver.adelete(docs)
-            assert (
-                len(await self._collect_async_items(loader.alazy_load())) == 0
-            )
-        finally:
-            await self._cleanup_table(engine)
+        await saver.adelete(docs)
+        assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        # finally:
+        # await self._cleanup_table(engine)
 
     @pytest.mark.parametrize(
         "metadata_json_column", [None, "metadata_col_test"]
@@ -750,7 +744,7 @@ class TestLoaderAsync:
     async def test_delete_doc_with_customized_metadata(
         self, engine, metadata_json_column
     ):
-        await self._cleanup_table(engine)
+        # await self._cleanup_table(engine)
         content_column = "content_col_test"
         await engine.ainit_document_table(
             table_name,
@@ -806,7 +800,6 @@ class TestLoaderAsync:
 
 @pytest.mark.asyncio
 class TestLoaderSync:
-
     def _cleanup_table(self, engine):
         query = f'DROP TABLE IF EXISTS "{table_name}"'
         engine._execute(query)
@@ -833,34 +826,34 @@ class TestLoaderSync:
         assert engine
 
     async def test_load_from_query_default_sync(self, sync_engine):
-        try:
-            self._cleanup_table(sync_engine)
-            sync_engine.init_document_table(table_name)
-            saver = PostgresDocumentSaver.create_sync(
-                engine=sync_engine, table_name=table_name
-            )
-            test_docs = [
-                Document(
-                    page_content="Cavendish 200 0.59 0",
-                    metadata={
-                        "fruit_id": 2,
-                        "fruit_name": "Banana",
-                        "organic": True,
-                    },
-                ),
-            ]
+        # try:
+        self._cleanup_table(sync_engine)
+        sync_engine.init_document_table(table_name)
+        saver = PostgresDocumentSaver.create_sync(
+            engine=sync_engine, table_name=table_name
+        )
+        test_docs = [
+            Document(
+                page_content="Cavendish 200 0.59 0",
+                metadata={
+                    "fruit_id": 2,
+                    "fruit_name": "Banana",
+                    "organic": True,
+                },
+            ),
+        ]
 
-            saver.add_documents(test_docs)
-            loader = PostgresLoader.create_sync(
-                engine=sync_engine,
-                query=f'SELECT * FROM "{table_name}";',
-            )
-            documents = loader.load()
-            assert documents == test_docs
+        saver.add_documents(test_docs)
+        loader = PostgresLoader.create_sync(
+            engine=sync_engine,
+            query=f'SELECT * FROM "{table_name}";',
+        )
+        documents = loader.load()
+        assert documents == test_docs
 
-            saver.delete(test_docs)
-            documents = loader.load()
-            assert len(documents) == 0
+        saver.delete(test_docs)
+        documents = loader.load()
+        assert len(documents) == 0
 
-        finally:
-            self._cleanup_table(sync_engine)
+        # finally:
+        self._cleanup_table(sync_engine)

--- a/tests/test_postgresql_loader.py
+++ b/tests/test_postgresql_loader.py
@@ -130,9 +130,7 @@ class TestLoaderAsync:
         # finally:
         # await self._cleanup_table(engine)
 
-    async def test_load_from_query_customized_content_customized_metadata(
-        self, engine
-    ):
+    async def test_load_from_query_customized_content_customized_metadata(self, engine):
         # try:
         # await self._cleanup_table(engine)
         query = f"""
@@ -168,7 +166,8 @@ class TestLoaderAsync:
             metadata_columns=["fruit_id"],
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         assert documents == [
             Document(
@@ -188,9 +187,7 @@ class TestLoaderAsync:
         # finally:
         # await self._cleanup_table(engine)
 
-    async def test_load_from_query_customized_content_default_metadata(
-        self, engine
-    ):
+    async def test_load_from_query_customized_content_default_metadata(self, engine):
         # try:
         # await self._cleanup_table(engine)
         query = f"""
@@ -221,7 +218,8 @@ class TestLoaderAsync:
             ],
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         assert documents == [
             Document(
@@ -245,7 +243,8 @@ class TestLoaderAsync:
             format="JSON",
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         assert documents == [
             Document(
@@ -261,9 +260,7 @@ class TestLoaderAsync:
         # finally:
         # await self._cleanup_table(engine)
 
-    async def test_load_from_query_default_content_customized_metadata(
-        self, engine
-    ):
+    async def test_load_from_query_default_content_customized_metadata(self, engine):
         # try:
         # await self._cleanup_table(engine)
         query = f"""
@@ -295,14 +292,19 @@ class TestLoaderAsync:
             metadata_columns=["fruit_name", "organic"],
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = loader.lazy_load()
 
-        assert documents == [
-            Document(
-                page_content="1",
-                metadata={"fruit_name": "Apple", "organic": 1},
-            )
-        ]
+        assert next(documents) == Document(
+            page_content="1",
+            metadata={"fruit_name": "Apple", "organic": 1},
+        )
+        # assert documents == [
+        #     Document(
+        #         page_content="1",
+        #         metadata={"fruit_name": "Apple", "organic": 1},
+        #     )
+        # ]
 
         # finally:
         # await self._cleanup_table(engine)
@@ -338,7 +340,8 @@ class TestLoaderAsync:
             ],
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         assert documents == [
             Document(
@@ -384,7 +387,8 @@ class TestLoaderAsync:
             ],
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         assert documents == [
             Document(
@@ -438,7 +442,8 @@ class TestLoaderAsync:
             formatter=my_formatter,
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         assert documents == [
             Document(
@@ -488,7 +493,8 @@ class TestLoaderAsync:
             format="YAML",
         )
 
-        documents = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         assert documents == [
             Document(
@@ -522,20 +528,15 @@ class TestLoaderAsync:
                 metadata={"fruit_id": 3},
             ),
         ]
-        saver = await PostgresDocumentSaver.create(
-            engine=engine, table_name=table_name
-        )
-        loader = await PostgresLoader.create(
-            engine=engine, table_name=table_name
-        )
+        saver = await PostgresDocumentSaver.create(engine=engine, table_name=table_name)
+        loader = await PostgresLoader.create(engine=engine, table_name=table_name)
 
         await saver.aadd_documents(test_docs)
-        docs = await self._collect_async_items(loader.alazy_load())
+        # documents = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
-        assert docs == test_docs
-        assert (
-            await engine._aload_table_schema(table_name)
-        ).columns.keys() == [
+        assert documents == test_docs
+        assert (await engine._aload_table_schema(table_name)).columns.keys() == [
             "page_content",
             "langchain_metadata",
         ]
@@ -543,9 +544,7 @@ class TestLoaderAsync:
         # await self._cleanup_table(engine)
 
     @pytest.mark.parametrize("store_metadata", [True, False])
-    async def test_save_doc_with_customized_metadata(
-        self, engine, store_metadata
-    ):
+    async def test_save_doc_with_customized_metadata(self, engine, store_metadata):
         # await self._cleanup_table(engine)
         await engine.ainit_document_table(
             table_name,
@@ -565,9 +564,7 @@ class TestLoaderAsync:
                 },
             ),
         ]
-        saver = await PostgresDocumentSaver.create(
-            engine=engine, table_name=table_name
-        )
+        saver = await PostgresDocumentSaver.create(engine=engine, table_name=table_name)
         loader = await PostgresLoader.create(
             engine=engine,
             table_name=table_name,
@@ -578,28 +575,25 @@ class TestLoaderAsync:
         )
 
         await saver.aadd_documents(test_docs)
-        docs = await self._collect_async_items(loader.alazy_load())
+        # docs = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
 
         if store_metadata:
-            docs == test_docs
-            assert (
-                await engine._aload_table_schema(table_name)
-            ).columns.keys() == [
+            documents == test_docs
+            assert (await engine._aload_table_schema(table_name)).columns.keys() == [
                 "page_content",
                 "fruit_name",
                 "organic",
                 "langchain_metadata",
             ]
         else:
-            assert docs == [
+            assert documents == [
                 Document(
                     page_content="Granny Smith 150 0.99",
                     metadata={"fruit_name": "Apple", "organic": True},
                 ),
             ]
-            assert (
-                await engine._aload_table_schema(table_name)
-            ).columns.keys() == [
+            assert (await engine._aload_table_schema(table_name)).columns.keys() == [
                 "page_content",
                 "fruit_name",
                 "organic",
@@ -619,9 +613,7 @@ class TestLoaderAsync:
                 },
             ),
         ]
-        saver = await PostgresDocumentSaver.create(
-            engine=engine, table_name=table_name
-        )
+        saver = await PostgresDocumentSaver.create(engine=engine, table_name=table_name)
         await saver.aadd_documents(test_docs)
 
         loader = await PostgresLoader.create(
@@ -630,6 +622,11 @@ class TestLoaderAsync:
         )
 
         docs = await self._collect_async_items(loader.alazy_load())
+        # results = []
+        # async for doc in loader.alazy_load():
+        #     results.append(doc)
+
+        # documents = await loader.aload()
 
         assert docs == [
             Document(
@@ -637,9 +634,7 @@ class TestLoaderAsync:
                 metadata={},
             ),
         ]
-        assert (
-            await engine._aload_table_schema(table_name)
-        ).columns.keys() == [
+        assert (await engine._aload_table_schema(table_name)).columns.keys() == [
             "page_content",
         ]
         # finally:
@@ -660,22 +655,23 @@ class TestLoaderAsync:
                 metadata={"fruit_id": 2},
             ),
         ]
-        saver = await PostgresDocumentSaver.create(
-            engine=engine, table_name=table_name
-        )
-        loader = await PostgresLoader.create(
-            engine=engine, table_name=table_name
-        )
+        saver = await PostgresDocumentSaver.create(engine=engine, table_name=table_name)
+        loader = await PostgresLoader.create(engine=engine, table_name=table_name)
 
         await saver.aadd_documents(test_docs)
-        docs = await self._collect_async_items(loader.alazy_load())
-        assert docs == test_docs
+        # docs = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
+        assert documents == test_docs
 
-        await saver.adelete(docs[:1])
-        assert len(await self._collect_async_items(loader.alazy_load())) == 1
+        await saver.adelete(documents[:1])
+        # assert len(await self._collect_async_items(loader.alazy_load())) == 1
+        documents = await loader.aload()
+        assert len(documents) == 1
 
-        await saver.adelete(docs)
-        assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        await saver.adelete(documents)
+        # assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        documents = await loader.aload()
+        assert len(documents) == 0
         # finally:
         # await self._cleanup_table(engine)
 
@@ -723,24 +719,23 @@ class TestLoaderAsync:
                 },
             ),
         ]
-        saver = await PostgresDocumentSaver.create(
-            engine=engine, table_name=table_name
-        )
+        saver = await PostgresDocumentSaver.create(engine=engine, table_name=table_name)
         query = f"SELECT * FROM \"{table_name}\" WHERE fruit_name='Apple';"
         loader = await PostgresLoader.create(engine=engine, query=query)
 
         await saver.aadd_documents(test_docs)
-        docs = await self._collect_async_items(loader.alazy_load())
-        assert len(docs) == 1
+        # docs = await self._collect_async_items(loader.alazy_load())
+        documents = await loader.aload()
+        assert len(documents) == 1
 
-        await saver.adelete(docs)
-        assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        await saver.adelete(documents)
+        # assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        documents = await loader.aload()
+        assert len(documents) == 0
         # finally:
         # await self._cleanup_table(engine)
 
-    @pytest.mark.parametrize(
-        "metadata_json_column", [None, "metadata_col_test"]
-    )
+    @pytest.mark.parametrize("metadata_json_column", [None, "metadata_col_test"])
     async def test_delete_doc_with_customized_metadata(
         self, engine, metadata_json_column
     ):
@@ -792,10 +787,14 @@ class TestLoaderAsync:
         assert len(docs) == 2
 
         await saver.adelete(docs[:1])
-        assert len(await self._collect_async_items(loader.alazy_load())) == 1
+        # assert len(await self._collect_async_items(loader.alazy_load())) == 1
+        documents = await loader.aload()
+        assert len(documents) == 1
 
         await saver.adelete(docs)
-        assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        # assert len(await self._collect_async_items(loader.alazy_load())) == 0
+        documents = await loader.aload()
+        assert len(documents) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -366,50 +366,50 @@ class TestVectorStore:
                 metadata_columns=["random_column"],
             )
 
-    async def test_from_engine(
-        self,
-        db_project,
-        db_region,
-        db_instance,
-        db_name,
-        user,
-        password,
-    ):
-        async def init_connection_pool(connector: Connector) -> AsyncEngine:
-            # initialize Connector object for connections to Cloud SQL
-            async def getconn():
-                conn = await connector.connect_async(
-                    f"{db_project}:{db_region}:{db_instance}",
-                    "asyncpg",
-                    user=user,
-                    password=password,
-                    db=db_name,
-                    enable_iam_auth=False,
-                    ip_type="PUBLIC",
-                )
-                return conn
+    # async def test_from_engine(
+    #     self,
+    #     db_project,
+    #     db_region,
+    #     db_instance,
+    #     db_name,
+    #     user,
+    #     password,
+    # ):
+    #     async def init_connection_pool(connector: Connector) -> AsyncEngine:
+    #         # initialize Connector object for connections to Cloud SQL
+    #         async def getconn():
+    #             conn = await connector.connect_async(
+    #                 f"{db_project}:{db_region}:{db_instance}",
+    #                 "asyncpg",
+    #                 user=user,
+    #                 password=password,
+    #                 db=db_name,
+    #                 enable_iam_auth=False,
+    #                 ip_type="PUBLIC",
+    #             )
+    #             return conn
 
-            # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-            # 'async_creator' argument to 'create_async_engine'
-            pool = create_async_engine(
-                "postgresql+asyncpg://",
-                async_creator=getconn,
-            )
-            return pool
+    #         # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
+    #         # 'async_creator' argument to 'create_async_engine'
+    #         pool = create_async_engine(
+    #             "postgresql+asyncpg://",
+    #             async_creator=getconn,
+    #         )
+    #         return pool
 
-        connector = await create_async_connector()
-        pool = await init_connection_pool(connector)
-        engine = PostgresEngine.from_engine(pool)
-        table_name = "from_engine_test" + str(uuid.uuid4())
-        engine.init_vectorstore_table(table_name, VECTOR_SIZE)
+    #     connector = await create_async_connector()
+    #     pool = await init_connection_pool(connector)
+    #     engine = PostgresEngine.from_engine(pool)
+    #     table_name = "from_engine_test" + str(uuid.uuid4())
+    #     engine.init_vectorstore_table(table_name, VECTOR_SIZE)
 
-        vs = await PostgresVectorStore.create(
-            engine,
-            embedding_service=embeddings_service,
-            table_name=table_name,
-        )
-        await vs.aadd_texts(["foo"])
-        assert len(await vs.similarity_search("foo")) == 1
-        await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
+    #     vs = await PostgresVectorStore.create(
+    #         engine,
+    #         embedding_service=embeddings_service,
+    #         table_name=table_name,
+    #     )
+    #     await vs.aadd_texts(["foo"])
+    #     assert len(await vs.similarity_search("foo")) == 1
+    #     await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
 
     # Need tests for store metadata=False

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -367,7 +367,7 @@ class TestVectorStore:
                 metadata_columns=["random_column"],
             )
 
-    async def test_from_engine_null(
+    async def test_from_engine(
         self,
         db_project,
         db_region,
@@ -377,7 +377,6 @@ class TestVectorStore:
         password,
     ):
         async def init_connection_pool(connector: Connector) -> AsyncEngine:
-            # initialize Connector object for connections to Cloud SQL
             async def getconn():
                 conn = await connector.connect_async(
                     f"{db_project}:{db_region}:{db_instance}",
@@ -390,12 +389,9 @@ class TestVectorStore:
                 )
                 return conn
 
-            # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-            # 'async_creator' argument to 'create_async_engine'
             pool = create_async_engine(
                 "postgresql+asyncpg://",
                 async_creator=getconn,
-                # poolclass=NullPool,
             )
             return pool
 

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -366,50 +366,52 @@ class TestVectorStore:
                 metadata_columns=["random_column"],
             )
 
-    # async def test_from_engine(
-    #     self,
-    #     db_project,
-    #     db_region,
-    #     db_instance,
-    #     db_name,
-    #     user,
-    #     password,
-    # ):
-    #     async def init_connection_pool(connector: Connector) -> AsyncEngine:
-    #         # initialize Connector object for connections to Cloud SQL
-    #         async def getconn():
-    #             conn = await connector.connect_async(
-    #                 f"{db_project}:{db_region}:{db_instance}",
-    #                 "asyncpg",
-    #                 user=user,
-    #                 password=password,
-    #                 db=db_name,
-    #                 enable_iam_auth=False,
-    #                 ip_type="PUBLIC",
-    #             )
-    #             return conn
+    async def test_from_engine(
+        self,
+        db_project,
+        db_region,
+        db_instance,
+        db_name,
+        user,
+        password,
+    ):
+        async def init_connection_pool(connector: Connector) -> AsyncEngine:
+            # initialize Connector object for connections to Cloud SQL
+            async def getconn():
+                conn = await connector.connect_async(
+                    f"{db_project}:{db_region}:{db_instance}",
+                    "asyncpg",
+                    user=user,
+                    password=password,
+                    db=db_name,
+                    enable_iam_auth=False,
+                    ip_type="PUBLIC",
+                )
+                return conn
 
-    #         # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-    #         # 'async_creator' argument to 'create_async_engine'
-    #         pool = create_async_engine(
-    #             "postgresql+asyncpg://",
-    #             async_creator=getconn,
-    #         )
-    #         return pool
+            # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
+            # 'async_creator' argument to 'create_async_engine'
+            pool = create_async_engine(
+                "postgresql+asyncpg://",
+                async_creator=getconn,
+            )
+            return pool
 
-    #     connector = await create_async_connector()
-    #     pool = await init_connection_pool(connector)
-    #     engine = PostgresEngine.from_engine(pool)
-    #     table_name = "from_engine_test" + str(uuid.uuid4())
-    #     engine.init_vectorstore_table(table_name, VECTOR_SIZE)
+        connector = await create_async_connector()
+        pool = await init_connection_pool(connector)
+        engine = PostgresEngine.from_engine(pool)
+        table_name = "from_engine_test" + str(uuid.uuid4())
+        await engine.ainit_vectorstore_table(table_name, VECTOR_SIZE)
 
-    #     vs = await PostgresVectorStore.create(
-    #         engine,
-    #         embedding_service=embeddings_service,
-    #         table_name=table_name,
-    #     )
-    #     await vs.aadd_texts(["foo"])
-    #     assert len(await vs.similarity_search("foo")) == 1
-    #     await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
+        vs = await PostgresVectorStore.create(
+            engine,
+            embedding_service=embeddings_service,
+            table_name=table_name,
+        )
+        await vs.aadd_texts(["foo"])
+        r = await vs.asimilarity_search("foo")
+        r = vs.similarity_search("foo")
+        assert len(r) == 1
+        await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
 
     # Need tests for store metadata=False

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -24,11 +24,7 @@ from langchain_core.embeddings import DeterministicFakeEmbedding
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import NullPool
 
-from langchain_google_cloud_sql_pg import (
-    Column,
-    PostgresEngine,
-    PostgresVectorStore,
-)
+from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4())
@@ -38,17 +34,12 @@ VECTOR_SIZE = 768
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz"]
-metadatas = [
-    {"page": str(i), "source": "google.com"} for i in range(len(texts))
-]
+metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i])
-    for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
 
-embeddings = [
-    embeddings_service.embed_query(texts[i]) for i in range(len(texts))
-]
+embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
 
 
 def get_env_var(key: str, desc: str) -> str:

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -66,6 +66,14 @@ class TestVectorStore:
     def db_name(self) -> str:
         return get_env_var("DATABASE_ID", "database name on cloud sql instance")
 
+    @pytest.fixture(scope="module")
+    def user(self) -> str:
+        return get_env_var("DB_USER", "database user for cloud sql")
+
+    @pytest.fixture(scope="module")
+    def password(self) -> str:
+        return get_env_var("DB_PASSWORD", "database password for cloud sql")
+
     @pytest_asyncio.fixture(scope="class")
     async def engine(self, db_project, db_region, db_instance, db_name):
         engine = await PostgresEngine.afrom_instance(

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -24,7 +24,11 @@ from langchain_core.embeddings import DeterministicFakeEmbedding
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import NullPool
 
-from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
+from langchain_google_cloud_sql_pg import (
+    Column,
+    PostgresEngine,
+    PostgresVectorStore,
+)
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4())
@@ -34,12 +38,17 @@ VECTOR_SIZE = 768
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz"]
-metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
+metadatas = [
+    {"page": str(i), "source": "google.com"} for i in range(len(texts))
+]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i])
+    for i in range(len(texts))
 ]
 
-embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
+embeddings = [
+    embeddings_service.embed_query(texts[i]) for i in range(len(texts))
+]
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -392,6 +401,7 @@ class TestVectorStore:
             pool = create_async_engine(
                 "postgresql+asyncpg://",
                 async_creator=getconn,
+                poolclass=NullPool,
             )
             return pool
 
@@ -412,5 +422,3 @@ class TestVectorStore:
         r2 = vs.similarity_search("foo")
         assert len(r2) == 1
         await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
-
-    # Need tests for store metadata=False

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -20,11 +20,7 @@ import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
 
-from langchain_google_cloud_sql_pg import (
-    Column,
-    PostgresEngine,
-    PostgresVectorStore,
-)
+from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4())
@@ -34,17 +30,12 @@ VECTOR_SIZE = 768
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz"]
-metadatas = [
-    {"page": str(i), "source": "google.com"} for i in range(len(texts))
-]
+metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i])
-    for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
 
-embeddings = [
-    embeddings_service.embed_query(texts[i]) for i in range(len(texts))
-]
+embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
 
 
 def get_env_var(key: str, desc: str) -> str:

--- a/tests/test_postgresql_vectorstore.py
+++ b/tests/test_postgresql_vectorstore.py
@@ -17,8 +17,11 @@ import uuid
 
 import pytest
 import pytest_asyncio
+import sqlalchemy
+from google.cloud.sql.connector import Connector, create_async_connector
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 
@@ -354,5 +357,51 @@ class TestVectorStore:
                 embedding_column="langchain_id",  # invalid embedding column data type
                 metadata_columns=["random_column"],
             )
+
+    async def test_from_engine(
+        self,
+        db_project,
+        db_region,
+        db_instance,
+        db_name,
+        user,
+        password,
+    ):
+        async def init_connection_pool(connector: Connector) -> AsyncEngine:
+            # initialize Connector object for connections to Cloud SQL
+            async def getconn():
+                conn = await connector.connect_async(
+                    f"{db_project}:{db_region}:{db_instance}",
+                    "asyncpg",
+                    user=user,
+                    password=password,
+                    db=db_name,
+                    enable_iam_auth=False,
+                    ip_type="PUBLIC",
+                )
+                return conn
+
+            # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
+            # 'async_creator' argument to 'create_async_engine'
+            pool = create_async_engine(
+                "postgresql+asyncpg://",
+                async_creator=getconn,
+            )
+            return pool
+
+        connector = await create_async_connector()
+        pool = await init_connection_pool(connector)
+        engine = PostgresEngine.from_engine(pool)
+        table_name = "from_engine_test" + str(uuid.uuid4())
+        engine.init_vectorstore_table(table_name, VECTOR_SIZE)
+
+        vs = await PostgresVectorStore.create(
+            engine,
+            embedding_service=embeddings_service,
+            table_name=table_name,
+        )
+        await vs.aadd_texts(["foo"])
+        assert len(await vs.similarity_search("foo")) == 1
+        await engine._aexecute(f'DROP TABLE IF EXISTS "{table_name}"')
 
     # Need tests for store metadata=False

--- a/tests/test_postgresql_vectorstore_from_methods.py
+++ b/tests/test_postgresql_vectorstore_from_methods.py
@@ -20,7 +20,11 @@ import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
 
-from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
+from langchain_google_cloud_sql_pg import (
+    Column,
+    PostgresEngine,
+    PostgresVectorStore,
+)
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4()).replace("-", "_")
@@ -31,12 +35,17 @@ VECTOR_SIZE = 768
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz"]
-metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
+metadatas = [
+    {"page": str(i), "source": "google.com"} for i in range(len(texts))
+]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i])
+    for i in range(len(texts))
 ]
 
-embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
+embeddings = [
+    embeddings_service.embed_query(texts[i]) for i in range(len(texts))
+]
 
 
 def get_env_var(key: str, desc: str) -> str:
@@ -85,6 +94,7 @@ class TestVectorStoreFromMethods:
         yield engine
         await engine._aexecute(f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await engine._aexecute(f"DROP TABLE IF EXISTS {CUSTOM_TABLE}")
+        await engine._connector.close_async()
         await engine._engine.dispose()
 
     @pytest_asyncio.fixture
@@ -100,7 +110,8 @@ class TestVectorStoreFromMethods:
         yield engine
         engine._execute(f"DROP TABLE IF EXISTS {DEFAULT_TABLE_SYNC}")
 
-        engine._engine.dispose()
+        engine._run_as_sync(engine._connector.close_async())
+        engine._run_as_sync(engine._engine.dispose())
 
     async def test_afrom_texts(self, engine):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]

--- a/tests/test_postgresql_vectorstore_from_methods.py
+++ b/tests/test_postgresql_vectorstore_from_methods.py
@@ -20,11 +20,7 @@ import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
 
-from langchain_google_cloud_sql_pg import (
-    Column,
-    PostgresEngine,
-    PostgresVectorStore,
-)
+from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 DEFAULT_TABLE_SYNC = "test_table_sync" + str(uuid.uuid4()).replace("-", "_")
@@ -35,17 +31,12 @@ VECTOR_SIZE = 768
 embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz"]
-metadatas = [
-    {"page": str(i), "source": "google.com"} for i in range(len(texts))
-]
+metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i])
-    for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
 
-embeddings = [
-    embeddings_service.embed_query(texts[i]) for i in range(len(texts))
-]
+embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
 
 
 def get_env_var(key: str, desc: str) -> str:

--- a/tests/test_postgresql_vectorstore_from_methods.py
+++ b/tests/test_postgresql_vectorstore_from_methods.py
@@ -167,6 +167,32 @@ class TestVectorStoreFromMethods:
         assert len(results) == 3
         engine_sync._execute(f"TRUNCATE TABLE {DEFAULT_TABLE_SYNC}")
 
+    async def test_afrom_docs_cross_env(self, engine_sync):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        await PostgresVectorStore.afrom_documents(
+            docs,
+            embeddings_service,
+            engine_sync,
+            DEFAULT_TABLE_SYNC,
+            ids=ids,
+        )
+        results = engine_sync._fetch(f"SELECT * FROM {DEFAULT_TABLE_SYNC}")
+        assert len(results) == 3
+        engine_sync._execute(f"TRUNCATE TABLE {DEFAULT_TABLE_SYNC}")
+
+    async def test_from_docs_cross_env(self, engine, engine_sync):
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        PostgresVectorStore.from_documents(
+            docs,
+            embeddings_service,
+            engine,
+            DEFAULT_TABLE_SYNC,
+            ids=ids,
+        )
+        results = await engine._afetch(f"SELECT * FROM {DEFAULT_TABLE_SYNC}")
+        assert len(results) == 3
+        await engine._aexecute(f"TRUNCATE TABLE {DEFAULT_TABLE_SYNC}")
+
     async def test_afrom_texts_custom(self, engine):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await PostgresVectorStore.afrom_texts(

--- a/tests/test_postgresql_vectorstore_index.py
+++ b/tests/test_postgresql_vectorstore_index.py
@@ -39,9 +39,12 @@ embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz"]
 ids = [str(uuid.uuid4()) for i in range(len(texts))]
-metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
+metadatas = [
+    {"page": str(i), "source": "google.com"} for i in range(len(texts))
+]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i])
+    for i in range(len(texts))
 ]
 
 embeddings = [embeddings_service.embed_query("foo") for i in range(len(texts))]
@@ -82,6 +85,9 @@ class TestIndex:
         )
         yield engine
 
+        await engine._connector.close_async()
+        await engine._engine.dispose()
+
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
         await engine.ainit_vectorstore_table(DEFAULT_TABLE, VECTOR_SIZE)
@@ -95,7 +101,6 @@ class TestIndex:
         await vs.adrop_vector_index()
         yield vs
         await engine._aexecute(f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
-        await engine._engine.dispose()
 
     @pytest.mark.run(order=1)
     async def test_aapply_vector_index(self, vs):

--- a/tests/test_postgresql_vectorstore_index.py
+++ b/tests/test_postgresql_vectorstore_index.py
@@ -135,6 +135,12 @@ class TestIndex:
         assert await vs.is_valid_index("secondindex")
         await vs.adrop_vector_index("secondindex")
 
+    async def test_aapply_vector_index_cross_env(self, vs):
+        index = IVFFlatIndex(distance_strategy=DistanceStrategy.EUCLIDEAN)
+        vs.apply_vector_index(index, concurrently=True)
+        assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
+        vs.drop_vector_index()
+
     async def test_is_valid_index(self, vs):
         is_valid = await vs.is_valid_index("invalid_index")
         assert is_valid == False

--- a/tests/test_postgresql_vectorstore_index.py
+++ b/tests/test_postgresql_vectorstore_index.py
@@ -39,12 +39,9 @@ embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz"]
 ids = [str(uuid.uuid4()) for i in range(len(texts))]
-metadatas = [
-    {"page": str(i), "source": "google.com"} for i in range(len(texts))
-]
+metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i])
-    for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
 
 embeddings = [embeddings_service.embed_query("foo") for i in range(len(texts))]

--- a/tests/test_postgresql_vectorstore_index.py
+++ b/tests/test_postgresql_vectorstore_index.py
@@ -132,12 +132,6 @@ class TestIndex:
         assert await vs.is_valid_index("secondindex")
         await vs.adrop_vector_index("secondindex")
 
-    async def test_aapply_vector_index_cross_env(self, vs):
-        index = IVFFlatIndex(distance_strategy=DistanceStrategy.EUCLIDEAN)
-        vs.apply_vector_index(index, concurrently=True)
-        assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
-        vs.drop_vector_index()
-
     async def test_is_valid_index(self, vs):
         is_valid = await vs.is_valid_index("invalid_index")
         assert is_valid == False

--- a/tests/test_postgresql_vectorstore_search.py
+++ b/tests/test_postgresql_vectorstore_search.py
@@ -152,6 +152,11 @@ class TestVectorStoreSearch:
         )
         assert results == [Document(page_content="bar")]
 
+    def test_asimilarity_search_cross_env(self, vs):
+        results = vs.similarity_search("foo", k=1)
+        assert len(results) == 1
+        assert results == [Document(page_content="foo")]
+
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")
         assert len(results) == 4

--- a/tests/test_postgresql_vectorstore_search.py
+++ b/tests/test_postgresql_vectorstore_search.py
@@ -20,15 +20,8 @@ import pytest_asyncio
 from langchain_core.documents import Document
 from langchain_core.embeddings import DeterministicFakeEmbedding
 
-from langchain_google_cloud_sql_pg import (
-    Column,
-    PostgresEngine,
-    PostgresVectorStore,
-)
-from langchain_google_cloud_sql_pg.indexes import (
-    DistanceStrategy,
-    HNSWQueryOptions,
-)
+from langchain_google_cloud_sql_pg import Column, PostgresEngine, PostgresVectorStore
+from langchain_google_cloud_sql_pg.indexes import DistanceStrategy, HNSWQueryOptions
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4()).replace("-", "_")
 CUSTOM_TABLE = "test_table_custom" + str(uuid.uuid4()).replace("-", "_")
@@ -38,12 +31,9 @@ embeddings_service = DeterministicFakeEmbedding(size=VECTOR_SIZE)
 
 texts = ["foo", "bar", "baz", "boo"]
 ids = [str(uuid.uuid4()) for i in range(len(texts))]
-metadatas = [
-    {"page": str(i), "source": "google.com"} for i in range(len(texts))
-]
+metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))]
 docs = [
-    Document(page_content=texts[i], metadata=metadatas[i])
-    for i in range(len(texts))
+    Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
 
 embeddings = [embeddings_service.embed_query("foo") for i in range(len(texts))]
@@ -147,9 +137,7 @@ class TestVectorStoreSearch:
         results = await vs.asimilarity_search("foo", k=1)
         assert len(results) == 1
         assert results == [Document(page_content="foo")]
-        results = await vs.asimilarity_search(
-            "foo", k=1, filter="content = 'bar'"
-        )
+        results = await vs.asimilarity_search("foo", k=1, filter="content = 'bar'")
         assert results == [Document(page_content="bar")]
 
     def test_asimilarity_search_cross_env(self, vs):
@@ -172,9 +160,7 @@ class TestVectorStoreSearch:
         assert results[0][0] == Document(page_content="foo")
         assert results[0][1] == 0
 
-    async def test_similarity_search_with_relevance_scores_threshold_cosine(
-        self, vs
-    ):
+    async def test_similarity_search_with_relevance_scores_threshold_cosine(self, vs):
         score_threshold = {"score_threshold": 0}
         results = await vs.asimilarity_search_with_relevance_scores(
             "foo", **score_threshold
@@ -240,9 +226,7 @@ class TestVectorStoreSearch:
         results = vs_custom.similarity_search("foo", k=1)
         assert len(results) == 1
         assert results == [Document(page_content="foo")]
-        results = vs_custom.similarity_search(
-            "foo", k=1, filter="mycontent = 'bar'"
-        )
+        results = vs_custom.similarity_search("foo", k=1, filter="mycontent = 'bar'")
         assert results == [Document(page_content="bar")]
 
     def test_similarity_search_score(self, vs_custom):

--- a/tests/test_postgresql_vectorstore_search.py
+++ b/tests/test_postgresql_vectorstore_search.py
@@ -131,7 +131,7 @@ class TestVectorStoreSearch:
         )
         vs_custom.add_documents(docs, ids=ids)
         yield vs_custom
-        engine_sync._aexecute(f"DROP TABLE IF EXISTS {CUSTOM_TABLE}")
+        engine_sync._execute(f"DROP TABLE IF EXISTS {CUSTOM_TABLE}")
 
     async def test_asimilarity_search(self, vs):
         results = await vs.asimilarity_search("foo", k=1)


### PR DESCRIPTION
Due to the use of an async driver, sync and async interfaces can not be mixed with the opposite environment.
If the Engine was initialized asynchronously, no self-managed loop is created therefore coroutines can not be scheduled to run synchronously. 
* If we try to run on the same loop, the task blocks the thread with the current loop and never completes.
* If the Engine was initialized synchronously, coroutines error since it is not attached to the native loop. 
LangChain interfaces support both async and sync calls for all methods. 

https://docs.google.com/document/d/1Cf73cs5hTV0rCakK7rjZAPLk9RIsw1AS7o7GcDoTQg0