### PR TITLE
fix: Fix QueryOptions not applied to similarity search bug

### DIFF
--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -327,7 +327,7 @@ class PostgresEngine:
             await conn.commit()
 
     async def _aexecute_outside_tx(self, query: str) -> None:
-        """Execute a SQL query."""
+        """Execute a SQL query in a new transaction."""
         async with self._engine.connect() as conn:
             await conn.execute(text("COMMIT"))
             await conn.execute(text(query))
@@ -338,6 +338,18 @@ class PostgresEngine:
         """Fetch results from a SQL query."""
         async with self._engine.connect() as conn:
             result = await conn.execute(text(query), params)
+            result_map = result.mappings()
+            result_fetch = result_map.fetchall()
+
+        return result_fetch
+
+    async def _afetch_with_query_options(
+        self, query: str, query_options: str
+    ) -> Sequence[RowMapping]:
+        """Set temporary database flags and fetch results from a SQL query."""
+        async with self._engine.connect() as conn:
+            await conn.execute(text(query_options))
+            result = await conn.execute(text(query))
             result_map = result.mappings()
             result_fetch = result_map.fetchall()
 

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -602,6 +602,7 @@ class PostgresVectorStore(VectorStore):
             query_options_stmt = f"SET LOCAL {self.index_query_options.to_string()};"
             results = await self.engine._afetch_with_query_options(
                 stmt, query_options_stmt
+            )
         else:
             results = await self.engine._afetch(stmt)
         return results

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -599,10 +599,11 @@ class PostgresVectorStore(VectorStore):
         filter = f"WHERE {filter}" if filter else ""
         stmt = f"SELECT *, {search_function}({self.embedding_column}, '{embedding}') as distance FROM \"{self.table_name}\" {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
         if self.index_query_options:
-            await self.engine._aexecute(
-                f"SET LOCAL {self.index_query_options.to_string()};"
-            )
-        results = await self.engine._afetch(stmt)
+            query_options_stmt = f"SET LOCAL {self.index_query_options.to_string()};"
+            results = await self.engine._afetch_with_query_options(
+                stmt, query_options_stmt
+        else:
+            results = await self.engine._afetch(stmt)
         return results
 
     def similarity_search(


### PR DESCRIPTION
The index QueryOptions are set by executing SET LOCAL, whose effect only last within the same transaction. However, currently the similarity search is in a different transaction, which means the query options are never applied. I fixed this by creating a new _afetch_with_query_options(query, query_options) method that executes the query options statement before fetching similarity search result, and modify the search APIs to call this method instead of _afetch()