### PR TITLE
feat: allow non-uuid data types for vectorstore primary key

### DIFF
--- a/src/langchain_google_cloud_sql_pg/async_vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/async_vectorstore.py
@@ -226,10 +226,14 @@ class AsyncPostgresVectorStore(VectorStore):
         texts: Iterable[str],
         embeddings: List[List[float]],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Add embeddings to the table."""
+        """Add embeddings to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         if not ids:
             ids = [str(uuid.uuid4()) for _ in texts]
         if not metadatas:
@@ -276,10 +280,14 @@ class AsyncPostgresVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed texts and add to the table."""
+        """Embed texts and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         embeddings = self.embedding_service.embed_documents(list(texts))
         ids = await self.__aadd_embeddings(
             texts, embeddings, metadatas=metadatas, ids=ids, **kwargs
@@ -289,10 +297,14 @@ class AsyncPostgresVectorStore(VectorStore):
     async def aadd_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed documents and add to the table"""
+        """Embed documents and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
         ids = await self.aadd_texts(texts, metadatas=metadatas, ids=ids, **kwargs)
@@ -300,10 +312,14 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def adelete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
-        """Delete records from the table."""
+        """Delete records from the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         if not ids:
             return False
 
@@ -323,7 +339,7 @@ class AsyncPostgresVectorStore(VectorStore):
         table_name: str,
         schema_name: str = "public",
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -338,6 +354,7 @@ class AsyncPostgresVectorStore(VectorStore):
         **kwargs: Any,
     ) -> AsyncPostgresVectorStore:
         """Create an AsyncPostgresVectorStore instance from texts.
+
         Args:
             texts (List[str]): Texts to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
@@ -357,6 +374,9 @@ class AsyncPostgresVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             AsyncPostgresVectorStore
@@ -389,7 +409,7 @@ class AsyncPostgresVectorStore(VectorStore):
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -424,6 +444,9 @@ class AsyncPostgresVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             AsyncPostgresVectorStore
@@ -735,7 +758,7 @@ class AsyncPostgresVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
         raise NotImplementedError(
@@ -745,7 +768,7 @@ class AsyncPostgresVectorStore(VectorStore):
     def add_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
         raise NotImplementedError(
@@ -754,7 +777,7 @@ class AsyncPostgresVectorStore(VectorStore):
 
     def delete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
         raise NotImplementedError(
@@ -769,7 +792,7 @@ class AsyncPostgresVectorStore(VectorStore):
         engine: PostgresEngine,
         table_name: str,
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -789,7 +812,7 @@ class AsyncPostgresVectorStore(VectorStore):
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -483,7 +483,6 @@ class PostgresEngine:
     ) -> None:
         """
         Create a table for saving of vectors to be used with PostgresVectorStore.
-        If id column data type is invalid, an UNDEFINED_OBJECT_ERROR is thrown.
 
         Args:
             table_name (str): The Postgres database table name.

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -534,7 +534,6 @@ class PostgresEngine:
     ) -> None:
         """
         Create a table for saving of vectors to be used with PostgresVectorStore.
-        If id column data type is invalid, an UNDEFINED_OBJECT_ERROR is thrown.
 
         Args:
             table_name (str): The Postgres database table name.

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -553,7 +553,7 @@ class PostgresEngine:
             store_metadata (bool): Whether to store metadata in the table.
                 Default: True.
         Raises:
-            :class:`UndefinedObjectError <asyncpg.exceptions.UndefinedObjectError>`: if id column data type is invalid.
+            :class:`UndefinedObjectError <asyncpg.exceptions.UndefinedObjectError>`: if the `ids` data type does not match that of the `id_column`.
         """
         self._run_as_sync(
             self._ainit_vectorstore_table(

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -410,7 +410,7 @@ class PostgresEngine:
         embedding_column: str = "embedding",
         metadata_columns: List[Column] = [],
         metadata_json_column: str = "langchain_metadata",
-        id_column: str = "langchain_id",
+        id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
         store_metadata: bool = True,
     ) -> None:
@@ -430,14 +430,14 @@ class PostgresEngine:
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
-            id_column (str):  Name of the column to store ids.
-                Default: "langchain_id". Optional,
+            id_column (Union[str, Column]) : Column to store ids.
+                Default: "langchain_id" column name with data type UUID. Optional.
             overwrite_existing (bool): Whether to drop existing table. Default: False.
             store_metadata (bool): Whether to store metadata in the table.
                 Default: True.
-
         Raises:
             :class:`DuplicateTableError <asyncpg.exceptions.DuplicateTableError>`: if table already exists and overwrite flag is not set.
+            :class:`UndefinedObjectError <asyncpg.exceptions.UndefinedObjectError>`: if the data type of the id column is not a postgreSQL data type.
         """
         async with self._pool.connect() as conn:
             await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
@@ -450,8 +450,11 @@ class PostgresEngine:
                 )
                 await conn.commit()
 
+        id_data_type = "UUID" if isinstance(id_column, str) else id_column.data_type
+        id_column_name = id_column if isinstance(id_column, str) else id_column.name
+
         query = f"""CREATE TABLE "{schema_name}"."{table_name}"(
-            "{id_column}" UUID PRIMARY KEY,
+            "{id_column_name}" {id_data_type} PRIMARY KEY,
             "{content_column}" TEXT NOT NULL,
             "{embedding_column}" vector({vector_size}) NOT NULL"""
         for column in metadata_columns:
@@ -474,12 +477,13 @@ class PostgresEngine:
         embedding_column: str = "embedding",
         metadata_columns: List[Column] = [],
         metadata_json_column: str = "langchain_metadata",
-        id_column: str = "langchain_id",
+        id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
         store_metadata: bool = True,
     ) -> None:
         """
         Create a table for saving of vectors to be used with PostgresVectorStore.
+        If id column data type is invalid, an UNDEFINED_OBJECT_ERROR is thrown.
 
         Args:
             table_name (str): The Postgres database table name.
@@ -494,8 +498,8 @@ class PostgresEngine:
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
-            id_column (str):  Name of the column to store ids.
-                Default: "langchain_id". Optional,
+            id_column (Union[str, Column]) : Column to store ids.
+                Default: "langchain_id" column name with data type UUID. Optional.
             overwrite_existing (bool): Whether to drop existing table. Default: False.
             store_metadata (bool): Whether to store metadata in the table.
                 Default: True.
@@ -524,12 +528,13 @@ class PostgresEngine:
         embedding_column: str = "embedding",
         metadata_columns: List[Column] = [],
         metadata_json_column: str = "langchain_metadata",
-        id_column: str = "langchain_id",
+        id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
         store_metadata: bool = True,
     ) -> None:
         """
         Create a table for saving of vectors to be used with PostgresVectorStore.
+        If id column data type is invalid, an UNDEFINED_OBJECT_ERROR is thrown.
 
         Args:
             table_name (str): The Postgres database table name.
@@ -544,11 +549,13 @@ class PostgresEngine:
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
-            id_column (str):  Name of the column to store ids.
-                Default: "langchain_id". Optional,
+            id_column (Union[str, Column]) : Column to store ids.
+                Default: "langchain_id" column name with data type UUID. Optional.
             overwrite_existing (bool): Whether to drop existing table. Default: False.
             store_metadata (bool): Whether to store metadata in the table.
                 Default: True.
+        Raises:
+            :class:`UndefinedObjectError <asyncpg.exceptions.UndefinedObjectError>`: if id column data type is invalid.
         """
         self._run_as_sync(
             self._ainit_vectorstore_table(

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -187,10 +187,14 @@ class PostgresVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed texts and add to the table."""
+        """Embed texts and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return await self._engine._run_as_async(
             self.__vs.aadd_texts(texts, metadatas, ids, **kwargs)
         )
@@ -199,10 +203,14 @@ class PostgresVectorStore(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed texts and add to the table."""
+        """Embed texts and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return self._engine._run_as_sync(
             self.__vs.aadd_texts(texts, metadatas, ids, **kwargs)
         )
@@ -210,10 +218,14 @@ class PostgresVectorStore(VectorStore):
     async def aadd_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed documents and add to the table"""
+        """Embed documents and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return await self._engine._run_as_async(
             self.__vs.aadd_documents(documents, ids, **kwargs)
         )
@@ -221,28 +233,40 @@ class PostgresVectorStore(VectorStore):
     def add_documents(
         self,
         documents: List[Document],
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Embed documents and add to the table."""
+        """Embed documents and add to the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return self._engine._run_as_sync(
             self.__vs.aadd_documents(documents, ids, **kwargs)
         )
 
     async def adelete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
-        """Delete records from the table."""
+        """Delete records from the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return await self._engine._run_as_async(self.__vs.adelete(ids, **kwargs))
 
     def delete(
         self,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
-        """Delete records from the table."""
+        """Delete records from the table.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
+        """
         return self._engine._run_as_sync(self.__vs.adelete(ids, **kwargs))
 
     @classmethod
@@ -254,7 +278,7 @@ class PostgresVectorStore(VectorStore):
         table_name: str,
         schema_name: str = "public",
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -268,6 +292,7 @@ class PostgresVectorStore(VectorStore):
         index_query_options: Optional[QueryOptions] = None,
     ) -> PostgresVectorStore:
         """Create an PostgresVectorStore instance from texts.
+
         Args:
             texts (List[str]): Texts to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
@@ -275,7 +300,7 @@ class PostgresVectorStore(VectorStore):
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List[str]]): List of IDs to add to table records.
+            ids: (Optional[List]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str]): Column(s) that represent a document's metadata.
@@ -287,6 +312,9 @@ class PostgresVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             PostgresVectorStore
@@ -319,7 +347,7 @@ class PostgresVectorStore(VectorStore):
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -341,7 +369,7 @@ class PostgresVectorStore(VectorStore):
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List[str]]): List of IDs to add to table records.
+            ids: (Optional[List]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str]): Column(s) that represent a document's metadata.
@@ -353,6 +381,9 @@ class PostgresVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             PostgresVectorStore
@@ -386,7 +417,7 @@ class PostgresVectorStore(VectorStore):
         table_name: str,
         schema_name: str = "public",
         metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -400,6 +431,7 @@ class PostgresVectorStore(VectorStore):
         index_query_options: Optional[QueryOptions] = None,
     ) -> PostgresVectorStore:
         """Create an PostgresVectorStore instance from texts.
+
         Args:
             texts (List[str]): Texts to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
@@ -407,7 +439,7 @@ class PostgresVectorStore(VectorStore):
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List[str]]): List of IDs to add to table records.
+            ids: (Optional[List]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str]): Column(s) that represent a document's metadata.
@@ -419,6 +451,9 @@ class PostgresVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             PostgresVectorStore
@@ -451,7 +486,7 @@ class PostgresVectorStore(VectorStore):
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List[str]] = None,
+        ids: Optional[List] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
         metadata_columns: List[str] = [],
@@ -473,7 +508,7 @@ class PostgresVectorStore(VectorStore):
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List[str]]): List of IDs to add to table records.
+            ids: (Optional[List]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
             metadata_columns (List[str]): Column(s) that represent a document's metadata.
@@ -485,6 +520,9 @@ class PostgresVectorStore(VectorStore):
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree of diversity among the results with 0 corresponding to maximum diversity and 1 to minimum diversity. Defaults to 0.5.
             index_query_options (QueryOptions): Index query option.
+
+        Raises:
+            :class:`InvalidTextRepresentationError <asyncpg.exceptions.InvalidTextRepresentationError>`: if the `ids` data type does not match that of the `id_column`.
 
         Returns:
             PostgresVectorStore


### PR DESCRIPTION
feat: allow non-uuid data types for vectorstore primary key
