### PR TITLE
ci: use Cloud SQL Proxy v2 for tests

### DIFF
--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -29,8 +29,8 @@ steps:
     args:
       - -c
       - |
-        wget -O /workspace/cloud_sql_proxy https://storage.googleapis.com/cloudsql-proxy/v1.37.0/cloud_sql_proxy.linux.386
-        chmod +x /workspace/cloud_sql_proxy
+        wget -O /workspace/cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.13.0/cloud-sql-proxy.linux.386
+        chmod +x /workspace/cloud-sql-proxy
 
   - id: Run integration tests
     name: python:${_VERSION}
@@ -45,7 +45,7 @@ steps:
     args:
       - "-c"
       - |
-        /workspace/cloud_sql_proxy -dir=/workspace -instances=${_INSTANCE_CONNECTION_NAME}=tcp:$_IP_ADDRESS:$_DATABASE_PORT  & sleep 2;
+        /workspace/cloud-sql-proxy ${_INSTANCE_CONNECTION_NAME} --port $_DATABASE_PORT  & sleep 2;
         python -m pytest --cov=langchain_google_cloud_sql_pg --cov-config=.coveragerc tests/
 
 availableSecrets:


### PR DESCRIPTION
Currently integration tests leverage the Cloud SQL Proxy v1 to
test `from_engine()`:
https://github.com/googleapis/langchain-google-cloud-sql-pg-python/blob/42baac64c9c5edba9e2ed53c983155579805fd5b/integration.cloudbuild.yaml#L32-L33

It is recommended to use the Cloud SQL Proxy v2 ([v2.13.0](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases/tag/v2.13.0) as of writing)
as it is more feature rich, stable, and has a better CLI interface.

This PR swaps out the v1 Cloud SQL Proxy for the v2 version as outlined
in the [migration guide](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/main/migration-guide.md#migrating-from-v1-to-v2).