### PR TITLE
chore: adhere to PEP 585 and removed unused imports

### DIFF
--- a/samples/index_tuning_sample/README.md
+++ b/samples/index_tuning_sample/README.md
@@ -174,7 +174,7 @@ class HNSWIndex(
     index_type: str = "hnsw",
     # Distance strategy does not affect recall and has minimal little on latency; refer to this guide to learn more https://cloud.google.com/spanner/docs/choose-vector-distance-function
     distance_strategy: DistanceStrategy = lambda : DistanceStrategy.COSINE_DISTANCE,
-    partial_indexes: List[str] | None = None,
+    partial_indexes: list[str] | None = None,
     m: int = 16,
     ef_construction: int = 64
 )
@@ -222,7 +222,7 @@ class IVFFlatIndex(
     name: str = DEFAULT_INDEX_NAME,
     index_type: str = "ivfflat",
     distance_strategy: DistanceStrategy = lambda : DistanceStrategy.COSINE_DISTANCE,
-    partial_indexes: List[str] | None = None,
+    partial_indexes: list[str] | None = None,
     lists: int = 1
 )
 

--- a/samples/langchain_on_vertexai/prebuilt_langchain_agent_template.py
+++ b/samples/langchain_on_vertexai/prebuilt_langchain_agent_template.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import List
 
 import vertexai  # type: ignore
 from config import (
@@ -38,14 +37,14 @@ from langchain_google_cloud_sql_pg import PostgresEngine, PostgresVectorStore
 engine = None  # Use global variable to share connection pooling
 
 
-def similarity_search(query: str) -> List[Document]:
+def similarity_search(query: str) -> list[Document]:
     """Searches and returns movies.
 
     Args:
       query: The user query to search for related items
 
     Returns:
-      List[Document]: A list of Documents
+      list[Document]: A list of Documents
     """
     global engine
     if not engine:  # Reuse connection pool

--- a/src/langchain_google_cloud_sql_pg/async_chat_message_history.py
+++ b/src/langchain_google_cloud_sql_pg/async_chat_message_history.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import json
-from typing import List, Sequence
+from typing import Sequence
 
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import BaseMessage, messages_from_dict
@@ -128,7 +128,7 @@ class AsyncPostgresChatMessageHistory(BaseChatMessageHistory):
             await conn.execute(text(query), {"session_id": self.session_id})
             await conn.commit()
 
-    async def _aget_messages(self) -> List[BaseMessage]:
+    async def _aget_messages(self) -> list[BaseMessage]:
         """Retrieve the messages from PostgreSQL."""
         query = f"""SELECT data, type FROM "{self.schema_name}"."{self.table_name}" WHERE session_id = :session_id ORDER BY id;"""
         async with self.pool.connect() as conn:

--- a/src/langchain_google_cloud_sql_pg/async_loader.py
+++ b/src/langchain_google_cloud_sql_pg/async_loader.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, AsyncIterator, Callable, Dict, Iterable, List, Optional
+from typing import Any, AsyncIterator, Callable, Iterable, Optional
 
 from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
@@ -28,24 +28,24 @@ DEFAULT_CONTENT_COL = "page_content"
 DEFAULT_METADATA_COL = "langchain_metadata"
 
 
-def text_formatter(row: dict, content_columns: List[str]) -> str:
+def text_formatter(row: dict, content_columns: list[str]) -> str:
     """txt document formatter."""
     return " ".join(str(row[column]) for column in content_columns if column in row)
 
 
-def csv_formatter(row: dict, content_columns: List[str]) -> str:
+def csv_formatter(row: dict, content_columns: list[str]) -> str:
     """CSV document formatter."""
     return ", ".join(str(row[column]) for column in content_columns if column in row)
 
 
-def yaml_formatter(row: dict, content_columns: List[str]) -> str:
+def yaml_formatter(row: dict, content_columns: list[str]) -> str:
     """YAML document formatter."""
     return "\n".join(
         f"{column}: {str(row[column])}" for column in content_columns if column in row
     )
 
 
-def json_formatter(row: dict, content_columns: List[str]) -> str:
+def json_formatter(row: dict, content_columns: list[str]) -> str:
     """JSON document formatter."""
     dictionary = {}
     for column in content_columns:
@@ -63,7 +63,7 @@ def _parse_doc_from_row(
 ) -> Document:
     """Parse row into document."""
     page_content = formatter(row, content_columns)
-    metadata: Dict[str, Any] = {}
+    metadata: dict[str, Any] = {}
     # unnest metadata from langchain_metadata column
     if metadata_json_column and row.get(metadata_json_column):
         for k, v in row[metadata_json_column].items():
@@ -81,10 +81,10 @@ def _parse_row_from_doc(
     column_names: Iterable[str],
     content_column: str = DEFAULT_CONTENT_COL,
     metadata_json_column: Optional[str] = DEFAULT_METADATA_COL,
-) -> Dict:
+) -> dict:
     """Parse document into a dictionary of rows."""
     doc_metadata = doc.metadata.copy()
-    row: Dict[str, Any] = {content_column: doc.page_content}
+    row: dict[str, Any] = {content_column: doc.page_content}
     for entry in doc.metadata:
         if entry in column_names:
             row[entry] = doc_metadata[entry]
@@ -111,8 +111,8 @@ class AsyncPostgresLoader(BaseLoader):
         key: object,
         pool: AsyncEngine,
         query: str,
-        content_columns: List[str],
-        metadata_columns: List[str],
+        content_columns: list[str],
+        metadata_columns: list[str],
         formatter: Callable,
         metadata_json_column: Optional[str] = None,
     ) -> None:
@@ -122,8 +122,8 @@ class AsyncPostgresLoader(BaseLoader):
             key (object): Prevent direct constructor usage.
             engine (PostgresEngine): AsyncEngine with pool connection to the postgres database
             query (Optional[str], optional): SQL query. Defaults to None.
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             formatter (Optional[Callable], optional): A function to format page content (OneOf: format, formatter). Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
 
@@ -150,8 +150,8 @@ class AsyncPostgresLoader(BaseLoader):
         query: Optional[str] = None,
         table_name: Optional[str] = None,
         schema_name: str = "public",
-        content_columns: Optional[List[str]] = None,
-        metadata_columns: Optional[List[str]] = None,
+        content_columns: Optional[list[str]] = None,
+        metadata_columns: Optional[list[str]] = None,
         metadata_json_column: Optional[str] = None,
         format: Optional[str] = None,
         formatter: Optional[Callable] = None,
@@ -163,8 +163,8 @@ class AsyncPostgresLoader(BaseLoader):
             query (Optional[str], optional): SQL query. Defaults to None.
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
             format (Optional[str], optional): Format of page content (OneOf: text, csv, YAML, JSON). Defaults to 'text'.
             formatter (Optional[Callable], optional): A function to format page content (OneOf: format, formatter). Defaults to None.
@@ -236,7 +236,7 @@ class AsyncPostgresLoader(BaseLoader):
             metadata_json_column,
         )
 
-    async def aload(self) -> List[Document]:
+    async def aload(self) -> list[Document]:
         """Load PostgreSQL data into Document objects."""
         return [doc async for doc in self.alazy_load()]
 
@@ -280,7 +280,7 @@ class AsyncPostgresDocumentSaver:
         table_name: str,
         content_column: str,
         schema_name: str = "public",
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         metadata_json_column: Optional[str] = None,
     ):
         """AsyncPostgresDocumentSaver constructor.
@@ -289,9 +289,9 @@ class AsyncPostgresDocumentSaver:
             key (object): Prevent direct constructor usage.
             engine (PostgresEngine): AsyncEngine with pool connection to the postgres database
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
 
         Raises:
@@ -315,7 +315,7 @@ class AsyncPostgresDocumentSaver:
         table_name: str,
         schema_name: str = "public",
         content_column: str = DEFAULT_CONTENT_COL,
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         metadata_json_column: Optional[str] = DEFAULT_METADATA_COL,
     ) -> AsyncPostgresDocumentSaver:
         """Create an AsyncPostgresDocumentSaver instance.
@@ -323,8 +323,8 @@ class AsyncPostgresDocumentSaver:
         Args:
             engine (PostgresEngine):AsyncEngine with pool connection to the postgres database
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
 
         Returns:
@@ -367,13 +367,13 @@ class AsyncPostgresDocumentSaver:
             metadata_json_column,
         )
 
-    async def aadd_documents(self, docs: List[Document]) -> None:
+    async def aadd_documents(self, docs: list[Document]) -> None:
         """
         Save documents in the DocumentSaver table. Document’s metadata is added to columns if found or
         stored in langchain_metadata JSON column.
 
         Args:
-            docs (List[langchain_core.documents.Document]): a list of documents to be saved.
+            docs (list[langchain_core.documents.Document]): a list of documents to be saved.
         """
 
         for doc in docs:
@@ -411,13 +411,13 @@ class AsyncPostgresDocumentSaver:
                 await conn.execute(text(query), row)
                 await conn.commit()
 
-    async def adelete(self, docs: List[Document]) -> None:
+    async def adelete(self, docs: list[Document]) -> None:
         """
         Delete all instances of a document from the DocumentSaver table by matching the entire Document
         object.
 
         Args:
-            docs (List[langchain_core.documents.Document]): a list of documents to be deleted.
+            docs (list[langchain_core.documents.Document]): a list of documents to be deleted.
         """
         for doc in docs:
             row = _parse_row_from_doc(

--- a/src/langchain_google_cloud_sql_pg/async_vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/async_vectorstore.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type
+from typing import Any, Callable, Iterable, Optional, Sequence
 
 import numpy as np
 from langchain_core.documents import Document
@@ -52,7 +52,7 @@ class AsyncPostgresVectorStore(VectorStore):
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         id_column: str = "langchain_id",
         metadata_json_column: Optional[str] = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -70,7 +70,7 @@ class AsyncPostgresVectorStore(VectorStore):
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             content_column (str): Column that represent a Document's page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -112,8 +112,8 @@ class AsyncPostgresVectorStore(VectorStore):
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: Optional[str] = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -131,8 +131,8 @@ class AsyncPostgresVectorStore(VectorStore):
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             content_column (str): Column that represent a Document's page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -224,11 +224,11 @@ class AsyncPostgresVectorStore(VectorStore):
     async def __aadd_embeddings(
         self,
         texts: Iterable[str],
-        embeddings: List[List[float]],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        embeddings: list[list[float]],
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Add embeddings to the table.
 
         Raises:
@@ -279,10 +279,10 @@ class AsyncPostgresVectorStore(VectorStore):
     async def aadd_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Embed texts and add to the table.
 
         Raises:
@@ -296,10 +296,10 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def aadd_documents(
         self,
-        documents: List[Document],
-        ids: Optional[List] = None,
+        documents: list[Document],
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Embed documents and add to the table.
 
         Raises:
@@ -312,7 +312,7 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def adelete(
         self,
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
         """Delete records from the table.
@@ -332,18 +332,18 @@ class AsyncPostgresVectorStore(VectorStore):
 
     @classmethod
     async def afrom_texts(  # type: ignore[override]
-        cls: Type[AsyncPostgresVectorStore],
-        texts: List[str],
+        cls: type[AsyncPostgresVectorStore],
+        texts: list[str],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -356,17 +356,17 @@ class AsyncPostgresVectorStore(VectorStore):
         """Create an AsyncPostgresVectorStore instance from texts.
 
         Args:
-            texts (List[str]): Texts to add to the vector store.
+            texts (list[str]): Texts to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
             engine (PostgresEngine): Connection pool engine for managing connections to Postgres database.
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List[str]]): List of IDs to add to table records.
+            metadatas (Optional[list[dict]]): List of metadatas to add to table records.
+            ids: (Optional[list[str]]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -403,17 +403,17 @@ class AsyncPostgresVectorStore(VectorStore):
 
     @classmethod
     async def afrom_documents(  # type: ignore[override]
-        cls: Type[AsyncPostgresVectorStore],
-        documents: List[Document],
+        cls: type[AsyncPostgresVectorStore],
+        documents: list[Document],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -426,17 +426,17 @@ class AsyncPostgresVectorStore(VectorStore):
         """Create an AsyncPostgresVectorStore instance from documents.
 
         Args:
-            documents (List[Document]): Documents to add to the vector store.
+            documents (list[Document]): Documents to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
             engine (PostgresEngine): Connection pool engine for managing connections to Postgres database.
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List[str]]): List of IDs to add to table records.
+            metadatas (Optional[list[dict]]): List of metadatas to add to table records.
+            ids: (Optional[list[str]]): List of IDs to add to table records.
             content_column (str): Column that represent a Document's page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -475,7 +475,7 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def __query_collection(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
@@ -508,7 +508,7 @@ class AsyncPostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected by similarity search on query."""
         embedding = self.embedding_service.embed_query(text=query)
 
@@ -533,7 +533,7 @@ class AsyncPostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected by similarity search on query."""
         embedding = self.embedding_service.embed_query(query)
         docs = await self.asimilarity_search_with_score_by_vector(
@@ -543,11 +543,11 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def asimilarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected by vector similarity search."""
         docs_and_scores = await self.asimilarity_search_with_score_by_vector(
             embedding=embedding, k=k, filter=filter, **kwargs
@@ -557,11 +557,11 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def asimilarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected by vector similarity search."""
         results = await self.__query_collection(
             embedding=embedding, k=k, filter=filter, **kwargs
@@ -596,7 +596,7 @@ class AsyncPostgresVectorStore(VectorStore):
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance."""
         embedding = self.embedding_service.embed_query(text=query)
 
@@ -611,13 +611,13 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def amax_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance."""
         docs_and_scores = (
             await self.amax_marginal_relevance_search_with_score_by_vector(
@@ -634,13 +634,13 @@ class AsyncPostgresVectorStore(VectorStore):
 
     async def amax_marginal_relevance_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected using the maximal marginal relevance."""
         results = await self.__query_collection(
             embedding=embedding, k=fetch_k, filter=filter, **kwargs
@@ -749,7 +749,7 @@ class AsyncPostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
@@ -757,27 +757,27 @@ class AsyncPostgresVectorStore(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
 
     def add_documents(
         self,
-        documents: List[Document],
-        ids: Optional[List] = None,
+        documents: list[Document],
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
 
     def delete(
         self,
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
         raise NotImplementedError(
@@ -786,17 +786,17 @@ class AsyncPostgresVectorStore(VectorStore):
 
     @classmethod
     def from_texts(  # type: ignore[override]
-        cls: Type[AsyncPostgresVectorStore],
-        texts: List[str],
+        cls: type[AsyncPostgresVectorStore],
+        texts: list[str],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         **kwargs: Any,
@@ -807,16 +807,16 @@ class AsyncPostgresVectorStore(VectorStore):
 
     @classmethod
     def from_documents(  # type: ignore[override]
-        cls: Type[AsyncPostgresVectorStore],
-        documents: List[Document],
+        cls: type[AsyncPostgresVectorStore],
+        documents: list[Document],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         **kwargs: Any,
@@ -831,29 +831,29 @@ class AsyncPostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
 
     def similarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
 
     def similarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
@@ -866,33 +866,33 @@ class AsyncPostgresVectorStore(VectorStore):
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
 
     def max_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
 
     def max_marginal_relevance_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )

--- a/src/langchain_google_cloud_sql_pg/chat_message_history.py
+++ b/src/langchain_google_cloud_sql_pg/chat_message_history.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import Sequence
 
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import BaseMessage, messages_from_dict
@@ -107,7 +107,7 @@ class PostgresChatMessageHistory(BaseChatMessageHistory):
         return cls(cls.__create_key, engine, history)
 
     @property  # type: ignore[override]
-    def messages(self) -> List[BaseMessage]:
+    def messages(self) -> list[BaseMessage]:
         """The abstraction required a property."""
         return self._engine._run_as_sync(self._history._aget_messages())
 

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -18,7 +18,7 @@ import asyncio
 from concurrent.futures import Future
 from dataclasses import dataclass
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Awaitable, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Optional, TypeVar, Union
 
 import aiohttp
 import google.auth  # type: ignore
@@ -66,7 +66,7 @@ async def _get_iam_principal_email(
     url = f"https://oauth2.googleapis.com/tokeninfo?access_token={credentials.token}"
     async with aiohttp.ClientSession() as client:
         response = await client.get(url, raise_for_status=True)
-        response_json: Dict = await response.json()
+        response_json: dict = await response.json()
         email = response_json.get("email")
     if email is None:
         raise ValueError(
@@ -408,7 +408,7 @@ class PostgresEngine:
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         metadata_json_column: str = "langchain_metadata",
         id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
@@ -426,7 +426,7 @@ class PostgresEngine:
                 Default: "page_content".
             embedding_column (str) : Name of the column to store vector embeddings.
                 Default: "embedding".
-            metadata_columns (List[Column]): A list of Columns to create for custom
+            metadata_columns (list[Column]): A list of Columns to create for custom
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
@@ -475,7 +475,7 @@ class PostgresEngine:
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         metadata_json_column: str = "langchain_metadata",
         id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
@@ -493,7 +493,7 @@ class PostgresEngine:
                 Default: "page_content".
             embedding_column (str) : Name of the column to store vector embeddings.
                 Default: "embedding".
-            metadata_columns (List[Column]): A list of Columns to create for custom
+            metadata_columns (list[Column]): A list of Columns to create for custom
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
@@ -525,7 +525,7 @@ class PostgresEngine:
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         metadata_json_column: str = "langchain_metadata",
         id_column: Union[str, Column] = "langchain_id",
         overwrite_existing: bool = False,
@@ -543,7 +543,7 @@ class PostgresEngine:
                 Default: "page_content".
             embedding_column (str) : Name of the column to store vector embeddings.
                 Default: "embedding".
-            metadata_columns (List[Column]): A list of Columns to create for custom
+            metadata_columns (list[Column]): A list of Columns to create for custom
                 metadata. Default: []. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
@@ -633,7 +633,7 @@ class PostgresEngine:
         table_name: str,
         schema_name: str = "public",
         content_column: str = "page_content",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         metadata_json_column: str = "langchain_metadata",
         store_metadata: bool = True,
     ) -> None:
@@ -657,7 +657,7 @@ class PostgresEngine:
         table_name: str,
         schema_name: str = "public",
         content_column: str = "page_content",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         metadata_json_column: str = "langchain_metadata",
         store_metadata: bool = True,
     ) -> None:
@@ -670,7 +670,7 @@ class PostgresEngine:
                 Default: "public".
             content_column (str): Name of the column to store document content.
                 Default: "page_content".
-            metadata_columns (List[sqlalchemy.Column]): A list of SQLAlchemy Columns
+            metadata_columns (list[sqlalchemy.Column]): A list of SQLAlchemy Columns
                 to create for custom metadata. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.
@@ -696,7 +696,7 @@ class PostgresEngine:
         table_name: str,
         schema_name: str = "public",
         content_column: str = "page_content",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         metadata_json_column: str = "langchain_metadata",
         store_metadata: bool = True,
     ) -> None:
@@ -709,7 +709,7 @@ class PostgresEngine:
                 Default: "public".
             content_column (str): Name of the column to store document content.
                 Default: "page_content".
-            metadata_columns (List[sqlalchemy.Column]): A list of SQLAlchemy Columns
+            metadata_columns (list[sqlalchemy.Column]): A list of SQLAlchemy Columns
                 to create for custom metadata. Optional.
             metadata_json_column (str): The column to store extra metadata in JSON format.
                 Default: "langchain_metadata". Optional.

--- a/src/langchain_google_cloud_sql_pg/indexes.py
+++ b/src/langchain_google_cloud_sql_pg/indexes.py
@@ -15,7 +15,7 @@
 import enum
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Optional
 
 
 @dataclass
@@ -44,7 +44,7 @@ class BaseIndex(ABC):
     distance_strategy: DistanceStrategy = field(
         default_factory=lambda: DistanceStrategy.COSINE_DISTANCE
     )
-    partial_indexes: Optional[List[str]] = None
+    partial_indexes: Optional[list[str]] = None
 
     @abstractmethod
     def index_options(self) -> str:

--- a/src/langchain_google_cloud_sql_pg/loader.py
+++ b/src/langchain_google_cloud_sql_pg/loader.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import AsyncIterator, Callable, Iterator, List, Optional
+from typing import AsyncIterator, Callable, Iterator, Optional
 
 from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
@@ -46,8 +46,8 @@ class PostgresLoader(BaseLoader):
             key (object): Prevent direct constructor usage.
             engine (PostgresEngine): AsyncEngine with pool connection to the postgres database
             query (Optional[str], optional): SQL query. Defaults to None.
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             formatter (Optional[Callable], optional): A function to format page content (OneOf: format, formatter). Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
 
@@ -70,8 +70,8 @@ class PostgresLoader(BaseLoader):
         query: Optional[str] = None,
         table_name: Optional[str] = None,
         schema_name: str = "public",
-        content_columns: Optional[List[str]] = None,
-        metadata_columns: Optional[List[str]] = None,
+        content_columns: Optional[list[str]] = None,
+        metadata_columns: Optional[list[str]] = None,
         metadata_json_column: Optional[str] = None,
         format: Optional[str] = None,
         formatter: Optional[Callable] = None,
@@ -83,8 +83,8 @@ class PostgresLoader(BaseLoader):
             query (Optional[str], optional): SQL query. Defaults to None.
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
             format (Optional[str], optional): Format of page content (OneOf: text, csv, YAML, JSON). Defaults to 'text'.
             formatter (Optional[Callable], optional): A function to format page content (OneOf: format, formatter). Defaults to None.
@@ -113,8 +113,8 @@ class PostgresLoader(BaseLoader):
         query: Optional[str] = None,
         table_name: Optional[str] = None,
         schema_name: str = "public",
-        content_columns: Optional[List[str]] = None,
-        metadata_columns: Optional[List[str]] = None,
+        content_columns: Optional[list[str]] = None,
+        metadata_columns: Optional[list[str]] = None,
         metadata_json_column: Optional[str] = None,
         format: Optional[str] = None,
         formatter: Optional[Callable] = None,
@@ -126,8 +126,8 @@ class PostgresLoader(BaseLoader):
             query (Optional[str], optional): SQL query. Defaults to None.
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
             format (Optional[str], optional): Format of page content (OneOf: text, csv, YAML, JSON). Defaults to 'text'.
             formatter (Optional[Callable], optional): A function to format page content (OneOf: format, formatter). Defaults to None.
@@ -149,11 +149,11 @@ class PostgresLoader(BaseLoader):
         loader = engine._run_as_sync(coro)
         return cls(cls.__create_key, engine, loader)
 
-    def load(self) -> List[Document]:
+    def load(self) -> list[Document]:
         """Load PostgreSQL data into Document objects."""
         return self._engine._run_as_sync(self._loader.aload())
 
-    async def aload(self) -> List[Document]:
+    async def aload(self) -> list[Document]:
         """Load PostgreSQL data into Document objects."""
         return await self._engine._run_as_async(self._loader.aload())
 
@@ -195,9 +195,9 @@ class PostgresDocumentSaver:
             key (object): Prevent direct constructor usage.
             engine (PostgresEngine): AsyncEngine with pool connection to the postgres database
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
 
         Raises:
@@ -217,7 +217,7 @@ class PostgresDocumentSaver:
         table_name: str,
         schema_name: str = "public",
         content_column: str = DEFAULT_CONTENT_COL,
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         metadata_json_column: Optional[str] = DEFAULT_METADATA_COL,
     ) -> PostgresDocumentSaver:
         """Create an PostgresDocumentSaver instance.
@@ -226,8 +226,8 @@ class PostgresDocumentSaver:
             engine (PostgresEngine):AsyncEngine with pool connection to the postgres database
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
 
         Returns:
@@ -251,7 +251,7 @@ class PostgresDocumentSaver:
         table_name: str,
         schema_name: str = "public",
         content_column: str = DEFAULT_CONTENT_COL,
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         metadata_json_column: str = DEFAULT_METADATA_COL,
     ) -> PostgresDocumentSaver:
         """Create an PostgresDocumentSaver instance.
@@ -260,8 +260,8 @@ class PostgresDocumentSaver:
             engine (PostgresEngine):AsyncEngine with pool connection to the postgres database
             table_name (Optional[str], optional): Name of table to query. Defaults to None.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            content_columns (Optional[List[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
-            metadata_columns (Optional[List[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
+            content_columns (Optional[list[str]], optional): Column that represent a Document's page_content. Defaults to the first column.
+            metadata_columns (Optional[list[str]], optional): Column(s) that represent a Document's metadata. Defaults to None.
             metadata_json_column (Optional[str], optional): Column to store metadata as JSON. Defaults to "langchain_metadata".
 
         Returns:
@@ -278,42 +278,42 @@ class PostgresDocumentSaver:
         saver = engine._run_as_sync(coro)
         return cls(cls.__create_key, engine, saver)
 
-    async def aadd_documents(self, docs: List[Document]) -> None:
+    async def aadd_documents(self, docs: list[Document]) -> None:
         """
         Save documents in the DocumentSaver table. Document’s metadata is added to columns if found or
         stored in langchain_metadata JSON column.
 
         Args:
-            docs (List[langchain_core.documents.Document]): a list of documents to be saved.
+            docs (list[langchain_core.documents.Document]): a list of documents to be saved.
         """
         await self._engine._run_as_async(self._saver.aadd_documents(docs))
 
-    def add_documents(self, docs: List[Document]) -> None:
+    def add_documents(self, docs: list[Document]) -> None:
         """
         Save documents in the DocumentSaver table. Document’s metadata is added to columns if found or
         stored in langchain_metadata JSON column.
 
         Args:
-            docs (List[langchain_core.documents.Document]): a list of documents to be saved.
+            docs (list[langchain_core.documents.Document]): a list of documents to be saved.
         """
         self._engine._run_as_sync(self._saver.aadd_documents(docs))
 
-    async def adelete(self, docs: List[Document]) -> None:
+    async def adelete(self, docs: list[Document]) -> None:
         """
         Delete all instances of a document from the DocumentSaver table by matching the entire Document
         object.
 
         Args:
-            docs (List[langchain_core.documents.Document]): a list of documents to be deleted.
+            docs (list[langchain_core.documents.Document]): a list of documents to be deleted.
         """
         await self._engine._run_as_async(self._saver.adelete(docs))
 
-    def delete(self, docs: List[Document]) -> None:
+    def delete(self, docs: list[Document]) -> None:
         """
         Delete all instances of a document from the DocumentSaver table by matching the entire Document
         object.
 
         Args:
-            docs (List[langchain_core.documents.Document]): a list of documents to be deleted.
+            docs (list[langchain_core.documents.Document]): a list of documents to be deleted.
         """
         self._engine._run_as_sync(self._saver.adelete(docs))

--- a/src/langchain_google_cloud_sql_pg/vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/vectorstore.py
@@ -15,7 +15,7 @@
 # TODO: Remove below import when minimum supported Python version is 3.10
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Type
+from typing import Any, Callable, Iterable, Optional
 
 import numpy as np
 from langchain_core.documents import Document
@@ -66,8 +66,8 @@ class PostgresVectorStore(VectorStore):
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: Optional[str] = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -85,8 +85,8 @@ class PostgresVectorStore(VectorStore):
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             content_column (str): Column that represent a Document's page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -127,8 +127,8 @@ class PostgresVectorStore(VectorStore):
         schema_name: str = "public",
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -146,8 +146,8 @@ class PostgresVectorStore(VectorStore):
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
             content_column (str): Column that represent a Document's page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -186,10 +186,10 @@ class PostgresVectorStore(VectorStore):
     async def aadd_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Embed texts and add to the table.
 
         Raises:
@@ -202,10 +202,10 @@ class PostgresVectorStore(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Embed texts and add to the table.
 
         Raises:
@@ -217,10 +217,10 @@ class PostgresVectorStore(VectorStore):
 
     async def aadd_documents(
         self,
-        documents: List[Document],
-        ids: Optional[List] = None,
+        documents: list[Document],
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Embed documents and add to the table.
 
         Raises:
@@ -232,10 +232,10 @@ class PostgresVectorStore(VectorStore):
 
     def add_documents(
         self,
-        documents: List[Document],
-        ids: Optional[List] = None,
+        documents: list[Document],
+        ids: Optional[list] = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Embed documents and add to the table.
 
         Raises:
@@ -247,7 +247,7 @@ class PostgresVectorStore(VectorStore):
 
     async def adelete(
         self,
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
         """Delete records from the table.
@@ -259,7 +259,7 @@ class PostgresVectorStore(VectorStore):
 
     def delete(
         self,
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         **kwargs: Any,
     ) -> Optional[bool]:
         """Delete records from the table.
@@ -271,18 +271,18 @@ class PostgresVectorStore(VectorStore):
 
     @classmethod
     async def afrom_texts(  # type: ignore[override]
-        cls: Type[PostgresVectorStore],
-        texts: List[str],
+        cls: type[PostgresVectorStore],
+        texts: list[str],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -294,17 +294,17 @@ class PostgresVectorStore(VectorStore):
         """Create an PostgresVectorStore instance from texts.
 
         Args:
-            texts (List[str]): Texts to add to the vector store.
+            texts (list[str]): Texts to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
             engine (PostgresEngine): Connection pool engine for managing connections to Postgres database.
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List]): List of IDs to add to table records.
+            metadatas (Optional[list[dict]]): List of metadatas to add to table records.
+            ids: (Optional[list]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -341,17 +341,17 @@ class PostgresVectorStore(VectorStore):
 
     @classmethod
     async def afrom_documents(  # type: ignore[override]
-        cls: Type[PostgresVectorStore],
-        documents: List[Document],
+        cls: type[PostgresVectorStore],
+        documents: list[Document],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -363,17 +363,17 @@ class PostgresVectorStore(VectorStore):
         """Create an PostgresVectorStore instance from documents.
 
         Args:
-            documents (List[Document]): Documents to add to the vector store.
+            documents (list[Document]): Documents to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
             engine (PostgresEngine): Connection pool engine for managing connections to Postgres database.
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List]): List of IDs to add to table records.
+            metadatas (Optional[list[dict]]): List of metadatas to add to table records.
+            ids: (Optional[list]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -410,18 +410,18 @@ class PostgresVectorStore(VectorStore):
 
     @classmethod
     def from_texts(  # type: ignore[override]
-        cls: Type[PostgresVectorStore],
-        texts: List[str],
+        cls: type[PostgresVectorStore],
+        texts: list[str],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List] = None,
+        metadatas: Optional[list[dict]] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -433,17 +433,17 @@ class PostgresVectorStore(VectorStore):
         """Create an PostgresVectorStore instance from texts.
 
         Args:
-            texts (List[str]): Texts to add to the vector store.
+            texts (list[str]): Texts to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
             engine (PostgresEngine): Connection pool engine for managing connections to Postgres database.
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List]): List of IDs to add to table records.
+            metadatas (Optional[list[dict]]): List of metadatas to add to table records.
+            ids: (Optional[list]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -480,17 +480,17 @@ class PostgresVectorStore(VectorStore):
 
     @classmethod
     def from_documents(  # type: ignore[override]
-        cls: Type[PostgresVectorStore],
-        documents: List[Document],
+        cls: type[PostgresVectorStore],
+        documents: list[Document],
         embedding: Embeddings,
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
-        ids: Optional[List] = None,
+        ids: Optional[list] = None,
         content_column: str = "content",
         embedding_column: str = "embedding",
-        metadata_columns: List[str] = [],
-        ignore_metadata_columns: Optional[List[str]] = None,
+        metadata_columns: list[str] = [],
+        ignore_metadata_columns: Optional[list[str]] = None,
         id_column: str = "langchain_id",
         metadata_json_column: str = "langchain_metadata",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -502,17 +502,17 @@ class PostgresVectorStore(VectorStore):
         """Create an PostgresVectorStore instance from documents.
 
         Args:
-            documents (List[Document]): Documents to add to the vector store.
+            documents (list[Document]): Documents to add to the vector store.
             embedding (Embeddings): Text embedding model to use.
             engine (PostgresEngine): Connection pool engine for managing connections to Postgres database.
             table_name (str): Name of the existing table or the table to be created.
             schema_name (str, optional): Database schema name of the table. Defaults to "public".
-            metadatas (Optional[List[dict]]): List of metadatas to add to table records.
-            ids: (Optional[List]): List of IDs to add to table records.
+            metadatas (Optional[list[dict]]): List of metadatas to add to table records.
+            ids: (Optional[list]): List of IDs to add to table records.
             content_column (str): Column that represent a Document’s page_content. Defaults to "content".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the document value. Defaults to "embedding".
-            metadata_columns (List[str]): Column(s) that represent a document's metadata.
-            ignore_metadata_columns (List[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
+            metadata_columns (list[str]): Column(s) that represent a document's metadata.
+            ignore_metadata_columns (list[str]): Column(s) to ignore in pre-existing tables for a document's metadata. Can not be used with metadata_columns. Defaults to None.
             id_column (str): Column that represents the Document's id. Defaults to "langchain_id".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "langchain_metadata".
             distance_strategy (DistanceStrategy): Distance strategy to use for vector similarity search. Defaults to COSINE_DISTANCE.
@@ -553,7 +553,7 @@ class PostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected by similarity search on query."""
         return await self._engine._run_as_async(
             self.__vs.asimilarity_search(query, k, filter, **kwargs)
@@ -565,7 +565,7 @@ class PostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected by similarity search on query."""
         return self._engine._run_as_sync(
             self.__vs.asimilarity_search(query, k, filter, **kwargs)
@@ -588,7 +588,7 @@ class PostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected by similarity search on query."""
         return await self._engine._run_as_async(
             self.__vs.asimilarity_search_with_score(query, k, filter, **kwargs)
@@ -600,7 +600,7 @@ class PostgresVectorStore(VectorStore):
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected by similarity search on query."""
         return self._engine._run_as_sync(
             self.__vs.asimilarity_search_with_score(query, k, filter, **kwargs)
@@ -608,11 +608,11 @@ class PostgresVectorStore(VectorStore):
 
     async def asimilarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected by vector similarity search."""
         return await self._engine._run_as_async(
             self.__vs.asimilarity_search_by_vector(embedding, k, filter, **kwargs)
@@ -620,11 +620,11 @@ class PostgresVectorStore(VectorStore):
 
     def similarity_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected by vector similarity search."""
         return self._engine._run_as_sync(
             self.__vs.asimilarity_search_by_vector(embedding, k, filter, **kwargs)
@@ -632,11 +632,11 @@ class PostgresVectorStore(VectorStore):
 
     async def asimilarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected by vector similarity search."""
         return await self._engine._run_as_async(
             self.__vs.asimilarity_search_with_score_by_vector(
@@ -646,11 +646,11 @@ class PostgresVectorStore(VectorStore):
 
     def similarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected by similarity search on vector."""
         return self._engine._run_as_sync(
             self.__vs.asimilarity_search_with_score_by_vector(
@@ -666,7 +666,7 @@ class PostgresVectorStore(VectorStore):
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance."""
         return await self._engine._run_as_async(
             self.__vs.amax_marginal_relevance_search(
@@ -682,7 +682,7 @@ class PostgresVectorStore(VectorStore):
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance."""
         return self._engine._run_as_sync(
             self.__vs.amax_marginal_relevance_search(
@@ -692,13 +692,13 @@ class PostgresVectorStore(VectorStore):
 
     async def amax_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance."""
         return await self._engine._run_as_async(
             self.__vs.amax_marginal_relevance_search_by_vector(
@@ -708,13 +708,13 @@ class PostgresVectorStore(VectorStore):
 
     def max_marginal_relevance_search_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance."""
         return self._engine._run_as_sync(
             self.__vs.amax_marginal_relevance_search_by_vector(
@@ -724,13 +724,13 @@ class PostgresVectorStore(VectorStore):
 
     async def amax_marginal_relevance_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected using the maximal marginal relevance."""
         return await self._engine._run_as_async(
             self.__vs.amax_marginal_relevance_search_with_score_by_vector(
@@ -740,13 +740,13 @@ class PostgresVectorStore(VectorStore):
 
     def max_marginal_relevance_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: Optional[int] = None,
         fetch_k: Optional[int] = None,
         lambda_mult: Optional[float] = None,
         filter: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[tuple[Document, float]]:
         """Return docs and distance scores selected using the maximal marginal relevance."""
         return self._engine._run_as_sync(
             self.__vs.amax_marginal_relevance_search_with_score_by_vector(

--- a/tests/test_async_chatmessagehistory.py
+++ b/tests/test_async_chatmessagehistory.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import os
 import uuid
-from typing import Any, Generator
 
 import pytest
 import pytest_asyncio

--- a/tests/test_chatmessagehistory.py
+++ b/tests/test_chatmessagehistory.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 import uuid
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 import pytest_asyncio


### PR DESCRIPTION
As of Python 3.9 and [PEP 585](https://peps.python.org/pep-0585/#implementation) we can use standard collections like
`list`, `dict`, `tuple` for typing instead of the  now deprecated

```python
from typing import Dict, List, Tuple ...
```

Also removing a ton of unused imports.