### PR TITLE
chore: support ids in Documents and update insert SQL query to upsert

### DIFF
--- a/src/langchain_google_cloud_sql_pg/async_vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/async_vectorstore.py
@@ -236,6 +236,8 @@ class AsyncPostgresVectorStore(VectorStore):
         """
         if not ids:
             ids = [str(uuid.uuid4()) for _ in texts]
+        else:
+            ids = [id if id is not None else str(uuid.uuid4()) for id in ids]
         if not metadatas:
             metadatas = [{} for _ in texts]
         # Insert embeddings
@@ -271,7 +273,17 @@ class AsyncPostgresVectorStore(VectorStore):
             else:
                 values_stmt += ")"
 
-            query = insert_stmt + values_stmt
+            upsert_stmt = f' ON CONFLICT ("{self.id_column}") DO UPDATE SET "{self.content_column}" = EXCLUDED."{self.content_column}", "{self.embedding_column}" = EXCLUDED."{self.embedding_column}"'
+
+            if self.metadata_json_column:
+                upsert_stmt += f', "{self.metadata_json_column}" = EXCLUDED."{self.metadata_json_column}"'
+
+            for column in self.metadata_columns:
+                upsert_stmt += f', "{column}" = EXCLUDED."{column}"'
+
+            upsert_stmt += ";"
+
+            query = insert_stmt + values_stmt + upsert_stmt
             async with self.pool.connect() as conn:
                 await conn.execute(text(query), values)
                 await conn.commit()
@@ -309,6 +321,8 @@ class AsyncPostgresVectorStore(VectorStore):
         """
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
+        if not ids:
+            ids = [doc.id for doc in documents]
         ids = await self.aadd_texts(texts, metadatas=metadatas, ids=ids, **kwargs)
         return ids
 
@@ -593,6 +607,7 @@ class AsyncPostgresVectorStore(VectorStore):
                     Document(
                         page_content=row[self.content_column],
                         metadata=metadata,
+                        id=row[self.id_column],
                     ),
                     row["distance"],
                 )
@@ -683,6 +698,7 @@ class AsyncPostgresVectorStore(VectorStore):
                     Document(
                         page_content=row[self.content_column],
                         metadata=metadata,
+                        id=row[self.id_column],
                     ),
                     row["distance"],
                 )

--- a/tests/test_async_vectorstore_search.py
+++ b/tests/test_async_vectorstore_search.py
@@ -98,7 +98,6 @@ class TestVectorStoreSearch:
             embedding_service=embeddings_service,
             table_name=DEFAULT_TABLE,
         )
-        ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_documents(docs, ids=ids)
         yield vs
 
@@ -132,23 +131,23 @@ class TestVectorStoreSearch:
     async def test_asimilarity_search(self, vs):
         results = await vs.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs.asimilarity_search("foo", k=1, filter="content = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")
         results = await vs.asimilarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = await vs.asimilarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold_cosine(self, vs):
@@ -171,7 +170,7 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
         score_threshold = {"score_threshold": 0.02}
         vs.distance_strategy = DistanceStrategy.EUCLIDEAN
@@ -195,78 +194,78 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_amax_marginal_relevance_search(self, vs):
         results = await vs.amax_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = await vs.amax_marginal_relevance_search(
             "bar", filter="content = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     async def test_amax_marginal_relevance_search_vector(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     async def test_amax_marginal_relevance_search_vector_score(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
     async def test_similarity_search(self, vs_custom):
         results = await vs_custom.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs_custom.asimilarity_search(
             "foo", k=1, filter="mycontent = 'bar'"
         )
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_similarity_search_score(self, vs_custom):
         results = await vs_custom.asimilarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_similarity_search_by_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("foo")
         results = await vs_custom.asimilarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = await vs_custom.asimilarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_max_marginal_relevance_search(self, vs_custom):
         results = await vs_custom.amax_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = await vs_custom.amax_marginal_relevance_search(
             "bar", filter="mycontent = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     async def test_max_marginal_relevance_search_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = await vs_custom.amax_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     async def test_max_marginal_relevance_search_vector_score(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = await vs_custom.amax_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = await vs_custom.amax_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])

--- a/tests/test_vectorstore_search.py
+++ b/tests/test_vectorstore_search.py
@@ -100,7 +100,6 @@ class TestVectorStoreSearch:
             embedding_service=embeddings_service,
             table_name=DEFAULT_TABLE,
         )
-        ids = [str(uuid.uuid4()) for i in range(len(texts))]
         await vs.aadd_documents(docs, ids=ids)
         yield vs
 
@@ -146,23 +145,23 @@ class TestVectorStoreSearch:
     async def test_asimilarity_search(self, vs):
         results = await vs.asimilarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = await vs.asimilarity_search("foo", k=1, filter="content = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     async def test_asimilarity_search_score(self, vs):
         results = await vs.asimilarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_asimilarity_search_by_vector(self, vs):
         embedding = embeddings_service.embed_query("foo")
         results = await vs.asimilarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = await vs.asimilarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     async def test_similarity_search_with_relevance_scores_threshold_cosine(self, vs):
@@ -185,7 +184,7 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_similarity_search_with_relevance_scores_threshold_euclidean(
         self, engine
@@ -202,32 +201,32 @@ class TestVectorStoreSearch:
             "foo", **score_threshold
         )
         assert len(results) == 1
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
 
     async def test_amax_marginal_relevance_search(self, vs):
         results = await vs.amax_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = await vs.amax_marginal_relevance_search(
             "bar", filter="content = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     async def test_amax_marginal_relevance_search_vector(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     async def test_amax_marginal_relevance_search_vector_score(self, vs):
         embedding = embeddings_service.embed_query("bar")
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = await vs.amax_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
 
 class TestVectorStoreSearchSync:
@@ -289,46 +288,46 @@ class TestVectorStoreSearchSync:
     def test_similarity_search(self, vs_custom):
         results = vs_custom.similarity_search("foo", k=1)
         assert len(results) == 1
-        assert results == [Document(page_content="foo")]
+        assert results == [Document(page_content="foo", id=ids[0])]
         results = vs_custom.similarity_search("foo", k=1, filter="mycontent = 'bar'")
-        assert results == [Document(page_content="bar")]
+        assert results == [Document(page_content="bar", id=ids[1])]
 
     def test_similarity_search_score(self, vs_custom):
         results = vs_custom.similarity_search_with_score("foo")
         assert len(results) == 4
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     def test_similarity_search_by_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("foo")
         results = vs_custom.similarity_search_by_vector(embedding)
         assert len(results) == 4
-        assert results[0] == Document(page_content="foo")
+        assert results[0] == Document(page_content="foo", id=ids[0])
         results = vs_custom.similarity_search_with_score_by_vector(embedding)
-        assert results[0][0] == Document(page_content="foo")
+        assert results[0][0] == Document(page_content="foo", id=ids[0])
         assert results[0][1] == 0
 
     def test_max_marginal_relevance_search(self, vs_custom):
         results = vs_custom.max_marginal_relevance_search("bar")
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
         results = vs_custom.max_marginal_relevance_search(
             "bar", filter="mycontent = 'boo'"
         )
-        assert results[0] == Document(page_content="boo")
+        assert results[0] == Document(page_content="boo", id=ids[3])
 
     def test_max_marginal_relevance_search_vector(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = vs_custom.max_marginal_relevance_search_by_vector(embedding)
-        assert results[0] == Document(page_content="bar")
+        assert results[0] == Document(page_content="bar", id=ids[1])
 
     def test_max_marginal_relevance_search_vector_score(self, vs_custom):
         embedding = embeddings_service.embed_query("bar")
         results = vs_custom.max_marginal_relevance_search_with_score_by_vector(
             embedding
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])
 
         results = vs_custom.max_marginal_relevance_search_with_score_by_vector(
             embedding, lambda_mult=0.75, fetch_k=10
         )
-        assert results[0][0] == Document(page_content="bar")
+        assert results[0][0] == Document(page_content="bar", id=ids[1])


### PR DESCRIPTION
chore: support ids in Documents and update insert SQL query to upsert

fixes [b/376065787](https://b.corp.google.com/issues/376065787)
