### PR TITLE
refactor: parse embedding dimensions as float[] for numpyV2

### DIFF
--- a/src/langchain_google_cloud_sql_pg/async_vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/async_vectorstore.py
@@ -246,7 +246,11 @@ class AsyncPostgresVectorStore(VectorStore):
                 else ""
             )
             insert_stmt = f'INSERT INTO "{self.schema_name}"."{self.table_name}"("{self.id_column}", "{self.content_column}", "{self.embedding_column}"{metadata_col_names}'
-            values = {"id": id, "content": content, "embedding": str(embedding)}
+            values = {
+                "id": id,
+                "content": content,
+                "embedding": str([float(dimension) for dimension in embedding]),
+            }
             values_stmt = "VALUES (:id, :content, :embedding"
 
             # Add metadata
@@ -496,9 +500,9 @@ class AsyncPostgresVectorStore(VectorStore):
             columns.append(self.metadata_json_column)
 
         column_names = ", ".join(f'"{col}"' for col in columns)
-
         filter = f"WHERE {filter}" if filter else ""
-        stmt = f"SELECT {column_names}, {search_function}({self.embedding_column}, '{embedding}') as distance FROM \"{self.schema_name}\".\"{self.table_name}\" {filter} ORDER BY {self.embedding_column} {operator} '{embedding}' LIMIT {k};"
+        embedding_string = f"'{[float(dimension) for dimension in embedding]}'"
+        stmt = f'SELECT {column_names}, {search_function}({self.embedding_column}, {embedding_string}) as distance FROM "{self.schema_name}"."{self.table_name}" {filter} ORDER BY {self.embedding_column} {operator} {embedding_string} LIMIT {k};'
         if self.index_query_options:
             async with self.pool.connect() as conn:
                 await conn.execute(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -130,7 +130,9 @@ class TestEngineAsync:
         id = str(uuid.uuid4())
         content = "coffee"
         embedding = await embeddings_service.aembed_query(content)
-        stmt = f"INSERT INTO {DEFAULT_TABLE} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding}');"
+        # Note: DeterministicFakeEmbedding generates a numpy array, converting to list a list of float values
+        embedding_string = [float(dimension) for dimension in embedding]
+        stmt = f"INSERT INTO {DEFAULT_TABLE} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding_string}');"
         await aexecute(engine, stmt)
 
     async def test_init_table_custom(self, engine):
@@ -350,7 +352,9 @@ class TestEngineSync:
         id = str(uuid.uuid4())
         content = "coffee"
         embedding = await embeddings_service.aembed_query(content)
-        stmt = f"INSERT INTO {DEFAULT_TABLE_SYNC} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding}');"
+        # Note: DeterministicFakeEmbedding generates a numpy array, converting to list a list of float values
+        embedding_string = [float(dimension) for dimension in embedding]
+        stmt = f"INSERT INTO {DEFAULT_TABLE_SYNC} (langchain_id, content, embedding) VALUES ('{id}', '{content}','{embedding_string}');"
         await aexecute(engine, stmt)
 
     async def test_init_table_custom(self, engine):


### PR DESCRIPTION
Per [this comment](https://github.com/googleapis/langchain-google-cloud-sql-pg-python/pull/251#issuecomment-2685689377), separating out the code changes for numpy #V2.

This change is needed because when using numpy V2, if a numpy array is converted to string then it comes as numpy objects rather than float array. [ref](https://github.com/googleapis/langchain-google-cloud-sql-pg-python/issues/247#issuecomment-2652914015)

## Changes include:
1. Parsing embedding dimensions individually for accommodating numpy V2 values.
2. Updating tests accordingly.



