### PR TITLE
chore(deps): update connectors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cloud-sql-python-connector[asyncpg]==1.17.0
+cloud-sql-python-connector[asyncpg]==1.18.1
 langchain-core==0.3.40
 numpy==2.2.3; python_version > "3.9"
 numpy== 2.0.2; python_version <= "3.9"

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -418,8 +418,7 @@ class PostgresEngine:
 
     async def close(self) -> None:
         """Dispose of connection pool"""
-        ## TODO: Uncomment before merge, commented to ensure sessions are not disposed
-        # await self._run_as_async(self._pool.dispose())
+        await self._run_as_async(self._pool.dispose())
 
     async def _ainit_vectorstore_table(
         self,

--- a/src/langchain_google_cloud_sql_pg/engine.py
+++ b/src/langchain_google_cloud_sql_pg/engine.py
@@ -418,7 +418,8 @@ class PostgresEngine:
 
     async def close(self) -> None:
         """Dispose of connection pool"""
-        await self._run_as_async(self._pool.dispose())
+        ## TODO: Uncomment before merge, commented to ensure sessions are not disposed
+        # await self._run_as_async(self._pool.dispose())
 
     async def _ainit_vectorstore_table(
         self,

--- a/tests/test_async_checkpoint.py
+++ b/tests/test_async_checkpoint.py
@@ -135,7 +135,6 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await async_engine.close()
-    await async_engine._connector.close_async()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -103,7 +103,6 @@ async def engine():
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name}"')
     await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name_writes}"')
     await engine.close()
-    await engine._connector.close_async()
 
 
 @pytest_asyncio.fixture
@@ -119,7 +118,6 @@ async def async_engine():
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_async}"')
     await aexecute(async_engine, f'DROP TABLE IF EXISTS "{table_name_writes_async}"')
     await async_engine.close()
-    await async_engine._connector.close_async()
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
The new version of connectors for Alloy DB are leading to test failures, ref tests in https://github.com/googleapis/langchain-google-cloud-sql-pg-python/pull/297.

This PR pins the issue to connector's latest version so that other packages can be unblocked from version updates.


### Tests hinting the issue is related to connectors (AND not session dispose)

1. In the first commit of PR, the session dispose is NOT commented out. This leads to failures like `RuntimeError: Session is closed` in several tests during test run. [Ref GCB log](https://pantheon.corp.google.com/cloud-build/builds/9d0c8618-9291-4af5-a4c6-f022b105f5d8;step=3?e=13802955&mods=logs_tg_staging&project=langchain-cloud-sql-testing)

2. In the second iteration of this PR, the session dispose is commented out ensuring sessions are not disposed/closed at all. This leads to `RuntimeError: Session is closed` failures in several tests. [Ref GCB log](https://pantheon.corp.google.com/cloud-build/builds/69146672-05b4-4b8a-8d62-34018d8e2673?project=langchain-cloud-sql-testing&e=13802955&mods=logs_tg_staging)

### Update
The errors seem like coming from an additional connector close, which is now removed in dd79dae2708d09ef68d6770be768e80cb22923de and 599cc54628175859a80702ad178167deb2e7abad