### PR TITLE
chore(lint): fix lint in checkpointer tests

### DIFF
--- a/tests/test_async_checkpoint.py
+++ b/tests/test_async_checkpoint.py
@@ -173,7 +173,7 @@ async def test_checkpoint_async(
 
 
 @pytest.fixture
-def test_data():
+def test_data() -> dict[str, Any]:
     """Fixture providing test data for checkpoint tests."""
     config_0: RunnableConfig = {"configurable": {"thread_id": "1", "checkpoint_ns": ""}}
     config_1: RunnableConfig = {
@@ -224,13 +224,13 @@ def test_data():
         "source": "input",
         "step": 2,
         "writes": {},
-        "parents": 1,
+        "parents": 1,  # type: ignore[typeddict-item]
     }
     metadata_2: CheckpointMetadata = {
         "source": "loop",
         "step": 1,
         "writes": {"foo": "bar"},
-        "parents": None,
+        "parents": None,  # type: ignore[typeddict-item]
     }
     metadata_3: CheckpointMetadata = {}
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -197,7 +197,7 @@ def test_checkpoint_table(engine: Any) -> None:
 
 
 @pytest.fixture
-def test_data():
+def test_data() -> dict[str, Any]:
     """Fixture providing test data for checkpoint tests."""
     config_0: RunnableConfig = {"configurable": {"thread_id": "1", "checkpoint_ns": ""}}
     config_1: RunnableConfig = {
@@ -248,13 +248,13 @@ def test_data():
         "source": "input",
         "step": 2,
         "writes": {},
-        "parents": 1,
+        "parents": 1,  # type: ignore[typeddict-item]
     }
     metadata_2: CheckpointMetadata = {
         "source": "loop",
         "step": 1,
         "writes": {"foo": "bar"},
-        "parents": None,
+        "parents": None,  # type: ignore[typeddict-item]
     }
     metadata_3: CheckpointMetadata = {}
 


### PR DESCRIPTION
Lint seems to be failing for checkpointer tests, [ref test log](https://github.com/googleapis/langchain-google-cloud-sql-pg-python/actions/runs/14626509139/job/41039195997?pr=297) in another PR: https://github.com/googleapis/langchain-google-cloud-sql-pg-python/pull/297