### PR TITLE
fix: Add support for a metadata column named id

### DIFF
--- a/src/langchain_google_cloud_sql_pg/async_vectorstore.py
+++ b/src/langchain_google_cloud_sql_pg/async_vectorstore.py
@@ -281,11 +281,11 @@ class AsyncPostgresVectorStore(VectorStore):
             )
             insert_stmt = f'INSERT INTO "{self.schema_name}"."{self.table_name}"("{self.id_column}", "{self.content_column}", "{self.embedding_column}"{metadata_col_names}'
             values = {
-                "id": id,
+                "langchain_id": id,
                 "content": content,
                 "embedding": str([float(dimension) for dimension in embedding]),
             }
-            values_stmt = "VALUES (:id, :content, :embedding"
+            values_stmt = "VALUES (:langchain_id, :content, :embedding"
 
             # Add metadata
             extra = copy.deepcopy(metadata)

--- a/tests/test_async_vectorstore.py
+++ b/tests/test_async_vectorstore.py
@@ -38,6 +38,7 @@ metadatas = [{"page": str(i), "source": "google.com"} for i in range(len(texts))
 docs = [
     Document(page_content=texts[i], metadata=metadatas[i]) for i in range(len(texts))
 ]
+id_column_as_metadata = [{"id": str(i)} for i in range(len(texts))]
 
 embeddings = [embeddings_service.embed_query(texts[i]) for i in range(len(texts))]
 
@@ -153,6 +154,29 @@ class TestVectorStore:
                 metadata_columns=["page", "source"],
                 metadata_json_column="mymeta",
             )
+
+    async def test_id_metadata_column(self, engine):
+        table_name = "id_metadata" + str(uuid.uuid4())
+        await engine._ainit_vectorstore_table(
+            table_name,
+            VECTOR_SIZE,
+            metadata_columns=[Column("id", "TEXT")],
+        )
+        custom_vs = await AsyncPostgresVectorStore.create(
+            engine,
+            embedding_service=embeddings_service,
+            table_name=table_name,
+            metadata_columns=["id"],
+        )
+        ids = [str(uuid.uuid4()) for i in range(len(texts))]
+        await custom_vs.aadd_texts(texts, id_column_as_metadata, ids)
+
+        results = await afetch(engine, f'SELECT * FROM "{table_name}"')
+        assert len(results) == 3
+        assert results[0]["id"] == "0"
+        assert results[1]["id"] == "1"
+        assert results[2]["id"] == "2"
+        await aexecute(engine, f'DROP TABLE IF EXISTS "{table_name}"')
 
     async def test_aadd_texts(self, engine, vs):
         ids = [str(uuid.uuid4()) for i in range(len(texts))]


### PR DESCRIPTION
fix: Add support for a metadata column named id

Fixes an issue that prevented adding a metadata column named id to the vector store, due to a conflict with the id parameter in the insert query. Users can now successfully include a metadata field with the name id.

Following the same fix as https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/421