### PR TITLE
chore: Set default priority as p0 to new PRs

### DIFF
--- a/.github/workflows/label-new-prs.yml
+++ b/.github/workflows/label-new-prs.yml
@@ -1,0 +1,22 @@
+name: Add Default P0 to New PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-p0-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add P0 label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [priority: p0]
+            })


### PR DESCRIPTION
This PRs adds a new github actions workflow to add default priority of P0 to new PRs
