### PR TITLE
chore: Update renovate to use `feat` type while updating langchain-postgres deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,6 +67,12 @@
       "matchPackageNames": ["numpy"],
       "matchCurrentValue": ">=1.24.4, <=2.0.2",
       "enabled": false
+    },
+    {
+      "description": "Use feat commit type for LangChain Postgres dependency updates",
+      "matchPackageNames": ["langchain-postgres"],
+      "semanticCommitType": "feat",
+      "groupName": "langchain-postgres"
     }
   ],
 }


### PR DESCRIPTION
chore: Update renovate to use feat type while updating langchain-postgres deps

