### PR TITLE
chore(deps): update dependency google-cloud-aiplatform to v2

### DIFF
--- a/samples/langchain_on_vertexai/requirements.txt
+++ b/samples/langchain_on_vertexai/requirements.txt
@@ -1,5 +1,6 @@
-google-cloud-aiplatform[reasoningengine,langchain]==1.134.0
+google-cloud-aiplatform[reasoningengine,langchain]==2.1.0
 google-cloud-resource-manager==1.16.0
+langchain-classic==1.0.8
 langchain-community==0.3.31
 langchain-google-cloud-sql-pg==0.15.0
 langchain-google-vertexai==2.1.2

--- a/samples/langchain_on_vertexai/retriever_agent_with_history_template.py
+++ b/samples/langchain_on_vertexai/retriever_agent_with_history_template.py
@@ -26,9 +26,9 @@ from config import (
     TABLE_NAME,
     USER,
 )
-from langchain import hub
-from langchain.agents import AgentExecutor, create_react_agent
-from langchain.tools.retriever import create_retriever_tool
+from langchain_classic import hub
+from langchain_classic.agents import AgentExecutor, create_react_agent
+from langchain_classic.tools.retriever import create_retriever_tool
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_google_vertexai import ChatVertexAI, VertexAIEmbeddings
 from vertexai.preview import reasoning_engines  # type: ignore

--- a/samples/langchain_on_vertexai/retriever_chain_template.py
+++ b/samples/langchain_on_vertexai/retriever_chain_template.py
@@ -25,8 +25,8 @@ from config import (
     TABLE_NAME,
     USER,
 )
-from langchain.chains.combine_documents import create_stuff_documents_chain
-from langchain.chains.retrieval import create_retrieval_chain
+from langchain_classic.chains.combine_documents import create_stuff_documents_chain
+from langchain_classic.chains.retrieval import create_retrieval_chain
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_google_vertexai import VertexAI, VertexAIEmbeddings
 from vertexai.preview import reasoning_engines  # type: ignore

--- a/samples/requirements.txt
+++ b/samples/requirements.txt
@@ -1,5 +1,6 @@
 google-cloud-aiplatform[reasoningengine,langchain]==2.1.0
 google-cloud-resource-manager==1.16.0
+langchain-classic==1.0.8
 langchain-community==0.3.29
 langchain-google-cloud-sql-pg==0.15.0
 langchain-google-vertexai==2.1.2

--- a/samples/requirements.txt
+++ b/samples/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-aiplatform[reasoningengine,langchain]==1.134.0
+google-cloud-aiplatform[reasoningengine,langchain]==2.1.0
 google-cloud-resource-manager==1.16.0
 langchain-community==0.3.29
 langchain-google-cloud-sql-pg==0.15.0


### PR DESCRIPTION
## Description

Supersedes #438 (cross-repo, so it couldn't be used as a base or pushed to). Carries renovate's bump plus the fix it needs.

aiplatform v2's `langchain` extra moves langchain `0.3` → `1.x`, which relocated the legacy agent/chain APIs into `langchain-classic`. Two Vertex sample templates still import from the old paths.

- Repoint `hub`, `AgentExecutor`, `create_react_agent`, `create_retriever_tool` and the two `chains` imports at `langchain_classic`. Behavior unchanged.
- Bump `samples/langchain_on_vertexai/requirements.txt` in lockstep — it's what `ReasoningEngine.create()` installs, so on v1 the deployed agent wouldn't find `langchain_classic`.
- Pin `langchain-classic` explicitly rather than relying on the extra.

## Issue Reference

Supersedes #438 
